### PR TITLE
Add InstanceSettings::builder

### DIFF
--- a/examples/federation/instance.rs
+++ b/examples/federation/instance.rs
@@ -11,7 +11,7 @@ use activitypub_federation::{
     data::Data,
     deser::context::WithContext,
     traits::ApubObject,
-    InstanceSettingsBuilder,
+    InstanceSettings,
     LocalInstance,
     APUB_JSON_CONTENT_TYPE,
 };
@@ -39,7 +39,7 @@ pub struct Instance {
 
 impl Instance {
     pub fn new(hostname: String) -> Result<InstanceHandle, Error> {
-        let settings = InstanceSettingsBuilder::default().debug(true).build()?;
+        let settings = InstanceSettings::builder().debug(true).build()?;
         let local_instance =
             LocalInstance::new(hostname.clone(), Client::default().into(), settings);
         let local_user = MyUser::new(generate_object_id(&hostname)?, generate_actor_keypair()?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,13 @@ pub struct InstanceSettings {
     verify_url_function: fn(&Url) -> Result<(), &'static str>,
 }
 
+impl InstanceSettings {
+    /// Returns a new settings builder.
+    pub fn builder() -> InstanceSettingsBuilder {
+        <_>::default()
+    }
+}
+
 impl LocalInstance {
     pub fn new(domain: String, client: ClientWithMiddleware, settings: InstanceSettings) -> Self {
         let activity_queue = create_activity_queue(client.clone(), &settings);


### PR DESCRIPTION
This provides a helper method to `InstanceSettings` so that you can write following.

```rust
InstanceSettingsBuilder::default() // Before
InstanceSettings::builder()        // After
```