### PR TITLE
Add keywords for crates.io discoverability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "activitypub_federation"
 version = "0.3.4"
 edition = "2021"
 description = "High-level Activitypub framework"
+keywords = ["activitypub", "activitystreams", "federation", "fediverse"]
 license = "AGPL-3.0"
 repository = "https://github.com/LemmyNet/activitypub-federation-rust"
 documentation = "https://docs.rs/activitypub_federation/"


### PR DESCRIPTION
I was looking for a crate like this using the `activitypub` keyword/tag on https://crates.io but didn't initially find the crate, so these keywords could help future people like myself.