### PR TITLE
feat: expose activity pub json wrapped value

### DIFF
--- a/src/deser/context.rs
+++ b/src/deser/context.rs
@@ -26,6 +26,10 @@ impl<T> WithContext<T> {
     pub fn new(inner: T, context: Vec<Value>) -> WithContext<T> {
         WithContext { context, inner }
     }
+
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
This is sometime needed when the same actor inbox receive activities from different actor types.
Here is an example from my project: 
```rust
async fn user_inbox(
    headers: HeaderMap,
    method: Method,
    OriginalUri(uri): OriginalUri,
    State(data): State<InstanceHandle>,
    Extension(digest_verified): Extension<DigestVerified>,
    Json(activity): Json<WithContext<PersonAcceptedActivities>>,
) -> impl IntoResponse {
    match activity.inner() {
        // Activities sent by `User` actors
        PersonAcceptedActivities::Follow(_) | PersonAcceptedActivities::CreateIssueComment(_) => {
            receive_activity::<WithContext<PersonAcceptedActivities>, User, InstanceHandle>(
                digest_verified,
                activity,
                &data.clone().local_instance,
                &Data::new(data),
                headers,
                method,
                uri,
            )
            .await
        }
        // Activities sent by `Repository` actors
        PersonAcceptedActivities::AcceptTicket(_) => {
            receive_activity::<WithContext<PersonAcceptedActivities>, Repository, InstanceHandle>(
                digest_verified,
                activity,
                &data.clone().local_instance,
                &Data::new(data),
                headers,
                method,
                uri,
            )
            .await
        }
    }
}
```