### PR TITLE
Multi webfinger response

### DIFF
--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -112,11 +112,9 @@ pub fn build_webfinger_response(subject: String, url: Url) -> Webfinger {
 /// let subject = "acct:nutomic@lemmy.ml".to_string();
 /// let user = Url::parse("https://lemmy.ml/u/nutomic")?;
 /// let group = Url::parse("https://lemmy.ml/c/asklemmy")?;
-/// let other = Url::parse("https://lemmy.ml/c/memes")?;
 /// build_webfinger_response_with_type(subject, vec![
 ///     (user, Some("Person")),
-///     (group, Some("Group")),
-///     (other, None)]);
+///     (group, Some("Group"))]);
 /// # Ok::<(), anyhow::Error>(())
 /// ```
 pub fn build_webfinger_response_with_type(


### PR DESCRIPTION
This PR adds support for multiple items in the webfinger response as well as being able to specify the type of the object. Corresponding docs and tests have also been updated.

The only mention of being able to specify a type is in the function's documentation. All the docs and tests only use `None` for kind.