### PR TITLE
Change username regex in webfinger

### DIFF
--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -71,8 +71,11 @@ where
     T: Clone,
 {
     // TODO: would be nice if we could implement this without regex and remove the dependency
-    let regex = Regex::new(&format!("^acct:([a-zA-Z0-9_]{{3,}})@{}$", data.domain()))
-        .map_err(Error::other)?;
+    let regex = Regex::new(&format!(
+        "^acct:((?i)[a-z0-9_]+([a-z0-9_\\.-]+[a-z0-9_]+)?)@{}$",
+        data.domain()
+    ))
+    .map_err(Error::other)?;
     Ok(regex
         .captures(query)
         .and_then(|c| c.get(1))

--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -71,6 +71,8 @@ where
     T: Clone,
 {
     // TODO: would be nice if we could implement this without regex and remove the dependency
+    // Regex taken from Mastodon -
+    // https://github.com/mastodon/mastodon/blob/2b113764117c9ab98875141bcf1758ba8be58173/app/models/account.rb#L65
     let regex = Regex::new(&format!(
         "^acct:((?i)[a-z0-9_]+([a-z0-9_\\.-]+[a-z0-9_]+)?)@{}$",
         data.domain()


### PR DESCRIPTION
This PR changes the regex used for username in `extract_webfinger_name` to include additional characters like '.' and '-'. This is the same regex used in Mastodon.

Some usernames may contain hyphens. The old regex made it impossible to get webfinger information for those usernames since it would always return an error.

There might be a better way to handle this though because as far as I can tell, the spec says nothing about what values are acceptable for `preferredUsername` so there may be some usernames with '+' or '%' or something else.