### PR TITLE
Change `domain` to `host_str`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -156,7 +156,7 @@ impl<T: Clone> FederationConfig<T> {
     /// Returns true if the url refers to this instance. Handles hostnames like `localhost:8540` for
     /// local debugging.
     pub(crate) fn is_local_url(&self, url: &Url) -> bool {
-        let mut domain = url.domain().expect("id has domain").to_string();
+        let mut domain = url.host_str().expect("id has domain").to_string();
         if let Some(port) = url.port() {
             domain = format!("{}:{}", domain, port);
         }


### PR DESCRIPTION
`ObjectId.dereference` panics if the URL's domain is an IP address. This PR fixes that.

```rust
let user1 = ObjectId::<User>::parse("http://127.0.0.1/user/grafcube")?;
let user2 = ObjectId::<User>::parse("http://fosstodon.org/@grafcube")?;
user1.dereference(&data).await // panics
user2.dereference(&data).await // doesn't panic
```