### PR TITLE
Specify in docs that `send_activity` takes remote inboxes

### DIFF
--- a/src/activity_queue.rs
+++ b/src/activity_queue.rs
@@ -38,8 +38,9 @@ use url::Url;
 /// - `activity`: The activity to be sent, gets converted to json
 /// - `private_key`: Private key belonging to the actor who sends the activity, for signing HTTP
 ///                  signature. Generated with [crate::http_signatures::generate_actor_keypair].
-/// - `inboxes`: List of actor inboxes that should receive the activity. Should be built by calling
-///              [crate::traits::Actor::shared_inbox_or_inbox] for each target actor.
+/// - `inboxes`: List of remote actor inboxes that should receive the activity. Ignores local actor
+///              inboxes. Should be built by calling [crate::traits::Actor::shared_inbox_or_inbox]
+///              for each target actor.
 pub async fn send_activity<Activity, Datatype, ActorType>(
     activity: Activity,
     actor: &ActorType,


### PR DESCRIPTION
Clarify that `send_activity` ignores any local URLs in `inboxes`.