### PR TITLE
Remove `actix-rt` and replace with tokio tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /.idea
 /Cargo.lock
+perf.data*
+flamegraph.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ openssl = "0.10.54"
 once_cell = "1.18.0"
 http = "0.2.9"
 sha2 = "0.10.6"
-background-jobs = "0.13.0"
 thiserror = "1.0.40"
 derive_builder = "0.12.0"
 itertools = "0.10.5"
@@ -37,6 +36,7 @@ futures-core = { version = "0.3.28", default-features = false }
 pin-project-lite = "0.2.9"
 activitystreams-kinds = "0.3.0"
 regex = { version = "1.8.4", default-features = false, features = ["std"] }
+tokio = { version = "1.21.2", features = ["sync", "rt", "time"]}
 
 # Actix-web
 actix-web = { version = "4.3.1", default-features = false, optional = true }
@@ -58,7 +58,7 @@ env_logger = "0.10.0"
 tower-http = { version = "0.4.0", features = ["map-request-body", "util"] }
 axum = { version = "0.6.18", features = ["http1", "tokio", "query"], default-features = false }
 axum-macros = "0.3.7"
-actix-rt = "2.8.0"
+tokio = { version = "1.21.2", features = ["full"]}
 
 [profile.dev]
 strip = "symbols"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,12 @@ futures-core = { version = "0.3.28", default-features = false }
 pin-project-lite = "0.2.9"
 activitystreams-kinds = "0.3.0"
 regex = { version = "1.8.4", default-features = false, features = ["std"] }
-tokio = { version = "1.21.2", features = ["sync", "rt", "time"] }
+tokio = { version = "1.21.2", features = [
+  "sync",
+  "rt",
+  "rt-multi-thread",
+  "time",
+] }
 
 # Actix-web
 actix-web = { version = "4.3.1", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,20 +29,26 @@ itertools = "0.10.5"
 dyn-clone = "1.0.11"
 enum_delegate = "0.2.0"
 httpdate = "1.0.2"
-http-signature-normalization-reqwest = { version = "0.8.0", default-features = false, features = ["sha-2", "middleware"] }
+http-signature-normalization-reqwest = { version = "0.8.0", default-features = false, features = [
+  "sha-2",
+  "middleware",
+] }
 http-signature-normalization = "0.7.0"
 bytes = "1.4.0"
 futures-core = { version = "0.3.28", default-features = false }
 pin-project-lite = "0.2.9"
 activitystreams-kinds = "0.3.0"
 regex = { version = "1.8.4", default-features = false, features = ["std"] }
-tokio = { version = "1.21.2", features = ["sync", "rt", "time"]}
+tokio = { version = "1.21.2", features = ["sync", "rt", "time"] }
 
 # Actix-web
 actix-web = { version = "4.3.1", default-features = false, optional = true }
 
 # Axum
-axum = { version = "0.6.18", features = ["json", "headers"], default-features = false, optional = true }
+axum = { version = "0.6.18", features = [
+  "json",
+  "headers",
+], default-features = false, optional = true }
 tower = { version = "0.4.13", optional = true }
 hyper = { version = "0.14", optional = true }
 displaydoc = "0.2.4"
@@ -56,9 +62,13 @@ axum = ["dep:axum", "dep:tower", "dep:hyper"]
 rand = "0.8.5"
 env_logger = "0.10.0"
 tower-http = { version = "0.4.0", features = ["map-request-body", "util"] }
-axum = { version = "0.6.18", features = ["http1", "tokio", "query"], default-features = false }
+axum = { version = "0.6.18", features = [
+  "http1",
+  "tokio",
+  "query",
+], default-features = false }
 axum-macros = "0.3.7"
-tokio = { version = "1.21.2", features = ["full"]}
+tokio = { version = "1.21.2", features = ["full"] }
 
 [profile.dev]
 strip = "symbols"

--- a/docs/05_configuration.md
+++ b/docs/05_configuration.md
@@ -5,12 +5,13 @@ Next we need to do some configuration. Most importantly we need to specify the d
 ```
 # use activitypub_federation::config::FederationConfig;
 # let db_connection = ();
-# let _ = actix_rt::System::new();
+# tokio::runtime::Runtime::new().unwrap().block_on(async {
 let config = FederationConfig::builder()
     .domain("example.com")
     .app_data(db_connection)
-    .build()?;
+    .build().await?;
 # Ok::<(), anyhow::Error>(())
+# }).unwrap()
 ```
 
 `debug` is necessary to test federation with http and localhost URLs, but it should never be used in production. The `worker_count` value can be adjusted depending on the instance size. A lower value saves resources on a small instance, while a higher value is necessary on larger instances to keep up with send jobs. `url_verifier` can be used to implement a domain blacklist.

--- a/docs/06_http_endpoints_axum.md
+++ b/docs/06_http_endpoints_axum.md
@@ -22,12 +22,12 @@ The next step is to allow other servers to fetch our actors and objects. For thi
 # use http::HeaderMap;
 # async fn generate_user_html(_: String, _: Data<DbConnection>) -> axum::response::Response { todo!() }
 
-#[actix_rt::main]
+#[tokio::main]
 async fn main() -> Result<(), Error> {
     let data = FederationConfig::builder()
         .domain("example.com")
         .app_data(DbConnection)
-        .build()?;
+        .build().await?;
         
     let app = axum::Router::new()
         .route("/user/:name", get(http_get_user))

--- a/docs/07_fetching_data.md
+++ b/docs/07_fetching_data.md
@@ -7,18 +7,17 @@ After setting up our structs, implementing traits and initializing configuration
 # use activitypub_federation::traits::tests::DbUser;
 # use activitypub_federation::config::FederationConfig;
 # let db_connection = activitypub_federation::traits::tests::DbConnection;
-# let _ = actix_rt::System::new();
-# actix_rt::Runtime::new().unwrap().block_on(async {
+# tokio::runtime::Runtime::new().unwrap().block_on(async {
 let config = FederationConfig::builder()
     .domain("example.com")
     .app_data(db_connection)
-    .build()?;
+    .build().await?;
 let user_id = ObjectId::<DbUser>::parse("https://mastodon.social/@LemmyDev")?;
 let data = config.to_request_data();
 let user = user_id.dereference(&data).await;
 assert!(user.is_ok());
 # Ok::<(), anyhow::Error>(())
-}).unwrap()
+# }).unwrap()
 ```
 
 `dereference` retrieves the object JSON at the given URL, and uses serde to convert it to `Person`. It then calls your method `Object::from_json` which inserts it in the database and returns a `DbUser` struct. `request_data` contains the federation config as well as a counter of outgoing HTTP requests. If this counter exceeds the configured maximum, further requests are aborted in order to avoid recursive fetching which could allow for a denial of service attack.
@@ -32,9 +31,8 @@ We can similarly dereference a user over webfinger with the following method. It
 # use activitypub_federation::fetch::webfinger::webfinger_resolve_actor;
 # use activitypub_federation::traits::tests::DbUser;
 # let db_connection = DbConnection;
-# let _ = actix_rt::System::new();
-# actix_rt::Runtime::new().unwrap().block_on(async {
-# let config = FederationConfig::builder().domain("example.com").app_data(db_connection).build()?;
+# tokio::runtime::Runtime::new().unwrap().block_on(async {
+# let config = FederationConfig::builder().domain("example.com").app_data(db_connection).build().await?;
 # let data = config.to_request_data();
 let user: DbUser = webfinger_resolve_actor("nutomic@lemmy.ml", &data).await?;
 # Ok::<(), anyhow::Error>(())

--- a/docs/09_sending_activities.md
+++ b/docs/09_sending_activities.md
@@ -9,13 +9,12 @@ To send an activity we need to initialize our previously defined struct, and pic
 # use activitypub_federation::traits::Actor;
 # use activitypub_federation::fetch::object_id::ObjectId;
 # use activitypub_federation::traits::tests::{DB_USER, DbConnection, Follow};
-# let _ = actix_rt::System::new();
-# actix_rt::Runtime::new().unwrap().block_on(async {
+# tokio::runtime::Runtime::new().unwrap().block_on(async {
 # let db_connection = DbConnection;
 # let config = FederationConfig::builder()
 #     .domain("example.com")
 #     .app_data(db_connection)
-#     .build()?;
+#     .build().await?;
 # let data = config.to_request_data();
 # let sender = DB_USER.clone();
 # let recipient = DB_USER.clone();

--- a/docs/10_fetching_objects_with_unknown_type.md
+++ b/docs/10_fetching_objects_with_unknown_type.md
@@ -61,9 +61,9 @@ impl Object for SearchableDbObjects {
     }
 }
 
-#[actix_rt::main]
+#[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    # let config = FederationConfig::builder().domain("example.com").app_data(DbConnection).build().unwrap();
+    # let config = FederationConfig::builder().domain("example.com").app_data(DbConnection).build().await.unwrap();
     # let data = config.to_request_data();
     let query = "https://example.com/id/413";
     let query_result = ObjectId::<SearchableDbObjects>::parse(query)?

--- a/examples/live_federation/main.rs
+++ b/examples/live_federation/main.rs
@@ -28,7 +28,7 @@ const DOMAIN: &str = "example.com";
 const LOCAL_USER_NAME: &str = "alison";
 const BIND_ADDRESS: &str = "localhost:8003";
 
-#[actix_rt::main]
+#[tokio::main]
 async fn main() -> Result<(), Error> {
     env_logger::builder()
         .filter_level(LevelFilter::Warn)
@@ -47,7 +47,8 @@ async fn main() -> Result<(), Error> {
     let config = FederationConfig::builder()
         .domain(DOMAIN)
         .app_data(database)
-        .build()?;
+        .build()
+        .await?;
 
     info!("Listen with HTTP server on {BIND_ADDRESS}");
     let config = config.clone();

--- a/examples/local_federation/actix_web/http.rs
+++ b/examples/local_federation/actix_web/http.rs
@@ -30,7 +30,7 @@ pub fn listen(config: &FederationConfig<DatabaseHandle>) -> Result<(), Error> {
     })
     .bind(hostname)?
     .run();
-    actix_rt::spawn(server);
+    tokio::spawn(server);
     Ok(())
 }
 

--- a/examples/local_federation/axum/http.rs
+++ b/examples/local_federation/axum/http.rs
@@ -41,7 +41,7 @@ pub fn listen(config: &FederationConfig<DatabaseHandle>) -> Result<(), Error> {
         .expect("Failed to lookup domain name");
     let server = axum::Server::bind(&addr).serve(app.into_make_service());
 
-    actix_rt::spawn(server);
+    tokio::spawn(server);
     Ok(())
 }
 

--- a/examples/local_federation/instance.rs
+++ b/examples/local_federation/instance.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use url::Url;
 
-pub fn new_instance(
+pub async fn new_instance(
     hostname: &str,
     name: String,
 ) -> Result<FederationConfig<DatabaseHandle>, Error> {
@@ -29,7 +29,8 @@ pub fn new_instance(
         .signed_fetch_actor(&system_user)
         .app_data(database)
         .debug(true)
-        .build()?;
+        .build()
+        .await?;
     Ok(config)
 }
 

--- a/examples/local_federation/main.rs
+++ b/examples/local_federation/main.rs
@@ -17,7 +17,7 @@ mod instance;
 mod objects;
 mod utils;
 
-#[actix_rt::main]
+#[tokio::main]
 async fn main() -> Result<(), Error> {
     env_logger::builder()
         .filter_level(LevelFilter::Warn)
@@ -32,8 +32,8 @@ async fn main() -> Result<(), Error> {
         .map(|arg| Webserver::from_str(&arg).unwrap())
         .unwrap_or(Webserver::Axum);
 
-    let alpha = new_instance("localhost:8001", "alpha".to_string())?;
-    let beta = new_instance("localhost:8002", "beta".to_string())?;
+    let alpha = new_instance("localhost:8001", "alpha".to_string()).await?;
+    let beta = new_instance("localhost:8002", "beta".to_string()).await?;
     listen(&alpha, &webserver)?;
     listen(&beta, &webserver)?;
     info!("Local instances started");

--- a/src/activity_queue.rs
+++ b/src/activity_queue.rs
@@ -30,8 +30,12 @@ use std::{
     time::{Duration, SystemTime},
 };
 use tokio::{
-    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
-    task::JoinHandle,
+    sync::{
+        mpsc::{unbounded_channel, UnboundedSender},
+        OwnedSemaphorePermit,
+        Semaphore,
+    },
+    task::{JoinHandle, JoinSet},
 };
 use tracing::{debug, info, warn};
 use url::Url;
@@ -65,10 +69,12 @@ where
         .ok_or_else(|| anyhow!("Actor {actor_id} does not contain a private key for signing"))?;
 
     // This is a mostly expensive blocking call, we don't want to tie up other tasks while this is happening
-    let private_key = tokio::task::block_in_place(|| {
+    let private_key = tokio::task::spawn_blocking(move || {
         PKey::private_key_from_pem(private_key_pem.as_bytes())
             .map_err(|err| anyhow!("Could not create private key from PEM data:{err}"))
-    })?;
+    })
+    .await
+    .map_err(|err| anyhow!("Error joining:{err}"))??;
 
     let inboxes: Vec<Url> = inboxes
         .into_iter()
@@ -95,13 +101,28 @@ where
             http_signature_compat: config.http_signature_compat,
         };
 
+        // Don't use the activity queue if this is in debug mode, send and wait directly
+        if config.debug {
+            if let Err(err) = sign_and_send(
+                &message,
+                &config.client,
+                config.request_timeout,
+                Default::default(),
+            )
+            .await
+            {
+                warn!("{err}");
+            }
+            return Ok(());
+        }
         activity_queue.queue(message).await?;
         let stats = activity_queue.get_stats();
         let running = stats.running.load(Ordering::Relaxed);
         let stats_fmt = format!(
-            "Activity queue stats: pending: {}, running: {}, dead: {}, complete: {}",
+            "Activity queue stats: pending: {}, running: {}, retries: {}, dead: {}, complete: {}",
             stats.pending.load(Ordering::Relaxed),
             running,
+            stats.retries.load(Ordering::Relaxed),
             stats.dead_last_hour.load(Ordering::Relaxed),
             stats.completed_last_hour.load(Ordering::Relaxed),
         );
@@ -130,6 +151,7 @@ async fn sign_and_send(
     task: &SendActivityTask,
     client: &ClientWithMiddleware,
     timeout: Duration,
+    retry_strategy: RetryStrategy,
 ) -> Result<(), anyhow::Error> {
     debug!("Sending {} to {}", task.activity_id, task.inbox);
     let request_builder = client
@@ -145,7 +167,19 @@ async fn sign_and_send(
     )
     .await?;
 
-    send(task, client, request).await
+    retry(
+        || {
+            send(
+                task,
+                client,
+                request
+                    .try_clone()
+                    .expect("The body of the request is not cloneable"),
+            )
+        },
+        retry_strategy,
+    )
+    .await
 }
 
 async fn send(
@@ -183,7 +217,7 @@ async fn send(
             ))
         }
         Err(e) => {
-            warn!(
+            debug!(
                 "Unable to connect to {}, aborting task {}: {}",
                 task.inbox, task.activity_id, e
             );
@@ -218,14 +252,11 @@ pub(crate) fn generate_request_headers(inbox_url: &Url) -> HeaderMap {
 /// When creating a queue, it will spawn a task per worker thread
 /// Uses an unbounded mpsc queue for communication (i.e, all messages are in memory)
 pub(crate) struct ActivityQueue {
-    // Our "background" tasks
-    senders: Vec<UnboundedSender<SendActivityTask>>,
-    handles: Vec<JoinHandle<()>>,
-    reset_handle: JoinHandle<()>,
-    // Round robin of the sender list
-    last_sender_idx: AtomicUsize,
     // Stats shared between the queue and workers
     stats: Arc<Stats>,
+    sender: UnboundedSender<SendActivityTask>,
+    sender_task: JoinHandle<()>,
+    retry_sender_task: JoinHandle<()>,
 }
 
 /// Simple stat counter to show where we're up to with sending messages
@@ -235,62 +266,120 @@ pub(crate) struct ActivityQueue {
 struct Stats {
     pending: AtomicUsize,
     running: AtomicUsize,
+    retries: AtomicUsize,
     dead_last_hour: AtomicUsize,
     completed_last_hour: AtomicUsize,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 struct RetryStrategy {
     /// Amount of time in seconds to back off
     backoff: usize,
     /// Amount of times to retry
     retries: usize,
+    /// If this particular request has already been retried, you can add an offset here to increment the count to start
+    offset: usize,
+    /// Number of seconds to sleep before trying
+    initial_sleep: usize,
 }
 
 /// A tokio spawned worker which is responsible for submitting requests to federated servers
+/// This will retry up to one time with the same signature, and if it fails, will move it to the retry queue.
+/// We need to retry activity sending in case the target instances is temporarily unreachable.
+/// In this case, the task is stored and resent when the instance is hopefully back up. This
+/// list shows the retry intervals, and which events of the target instance can be covered:
+/// - 60s (one minute, service restart) -- happens in the worker w/ same signature
+/// - 60min (one hour, instance maintenance) --- happens in the retry worker
+/// - 60h (2.5 days, major incident with rebuild from backup) --- happens in the retry worker
 async fn worker(
     client: ClientWithMiddleware,
     timeout: Duration,
-    mut receiver: UnboundedReceiver<SendActivityTask>,
+    message: SendActivityTask,
+    permit: OwnedSemaphorePermit,
+    retry_queue: UnboundedSender<SendActivityTask>,
     stats: Arc<Stats>,
     strategy: RetryStrategy,
 ) {
-    while let Some(message) = receiver.recv().await {
-        stats.pending.fetch_sub(1, Ordering::Relaxed);
-        stats.running.fetch_add(1, Ordering::Relaxed);
+    stats.pending.fetch_sub(1, Ordering::Relaxed);
+    stats.running.fetch_add(1, Ordering::Relaxed);
 
-        let outcome = retry(|| sign_and_send(&message, &client, timeout), strategy).await;
+    let outcome = sign_and_send(&message, &client, timeout, strategy).await;
 
-        // "Running" has finished, check the outcome
-        stats.running.fetch_sub(1, Ordering::Relaxed);
+    // "Running" has finished, check the outcome
+    stats.running.fetch_sub(1, Ordering::Relaxed);
 
-        match outcome {
-            Ok(_) => {
-                stats.completed_last_hour.fetch_add(1, Ordering::Relaxed);
-            }
-            Err(_err) => {
-                stats.dead_last_hour.fetch_add(1, Ordering::Relaxed);
-            }
+    match outcome {
+        Ok(_) => {
+            stats.completed_last_hour.fetch_add(1, Ordering::Relaxed);
+        }
+        Err(_err) => {
+            stats.retries.fetch_add(1, Ordering::Relaxed);
+            warn!(
+                "Sending activity {} to {} to the retry queue to be tried again later",
+                message.activity_id, message.inbox
+            );
+            // Send to the retry queue.  Ignoring whether it succeeds or not
+            retry_queue.send(message).ok();
         }
     }
+
+    drop(permit);
+}
+
+async fn retry_worker(
+    client: ClientWithMiddleware,
+    timeout: Duration,
+    message: SendActivityTask,
+    permit: OwnedSemaphorePermit,
+    stats: Arc<Stats>,
+    strategy: RetryStrategy,
+) {
+    // Because the times are pretty extravagant between retries, we have to re-sign each time
+    let outcome = retry(
+        || {
+            sign_and_send(
+                &message,
+                &client,
+                timeout,
+                RetryStrategy {
+                    backoff: 0,
+                    retries: 0,
+                    offset: 0,
+                    initial_sleep: 0,
+                },
+            )
+        },
+        strategy,
+    )
+    .await;
+
+    stats.retries.fetch_sub(1, Ordering::Relaxed);
+
+    match outcome {
+        Ok(_) => {
+            stats.completed_last_hour.fetch_add(1, Ordering::Relaxed);
+        }
+        Err(_err) => {
+            stats.dead_last_hour.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    drop(permit)
 }
 
 impl ActivityQueue {
     fn new(
         client: ClientWithMiddleware,
         worker_count: usize,
+        retry_count: usize,
         timeout: Duration,
-        strategy: RetryStrategy,
+        backoff: usize, // This should be 60 seconds by default or 1 second in tests
     ) -> Self {
-        // Keep a vec of senders to send our messages to
-        let mut senders = Vec::with_capacity(worker_count);
-        let mut handles = Vec::with_capacity(worker_count);
-
         let stats: Arc<Stats> = Default::default();
 
         // This task clears the dead/completed stats every hour
         let hour_stats = stats.clone();
-        let reset_handle = tokio::spawn(async move {
+        tokio::spawn(async move {
             let duration = Duration::from_secs(3600);
             loop {
                 tokio::time::sleep(duration).await;
@@ -299,36 +388,99 @@ impl ActivityQueue {
             }
         });
 
-        // Spawn our workers
-        for _ in 0..worker_count {
-            let (sender, receiver) = unbounded_channel();
-            handles.push(tokio::spawn(worker(
-                client.clone(),
-                timeout,
-                receiver,
-                stats.clone(),
-                strategy,
-            )));
-            senders.push(sender);
-        }
+        let (retry_sender, mut retry_receiver) = unbounded_channel();
+        let retry_stats = stats.clone();
+        let retry_client = client.clone();
+
+        // The "fast path" retry
+        // The backoff should be < 5 mins for this to work otherwise signatures may expire
+        // This strategy is the one that is used with the *same* signature
+        let strategy = RetryStrategy {
+            backoff,
+            retries: 1,
+            offset: 0,
+            initial_sleep: 0,
+        };
+
+        // The "retry path" strategy
+        // After the fast path fails, a task will sleep up to backoff ^ 2 and then retry again
+        let retry_strategy = RetryStrategy {
+            backoff,
+            retries: 3,
+            offset: 2,
+            initial_sleep: backoff.pow(2), // wait 60 mins before even trying
+        };
+
+        let retry_sender_task = tokio::spawn(async move {
+            let semaphore = Arc::new(Semaphore::new(retry_count));
+            let mut join_set = JoinSet::new();
+
+            while let Some(message) = retry_receiver.recv().await {
+                let permit = semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .expect("should never be closed");
+
+                join_set.spawn(retry_worker(
+                    retry_client.clone(),
+                    timeout,
+                    message,
+                    permit,
+                    retry_stats.clone(),
+                    retry_strategy,
+                ));
+            }
+
+            while !join_set.is_empty() {
+                join_set.join_next().await;
+            }
+        });
+
+        let (sender, mut receiver) = unbounded_channel();
+
+        let sender_stats = stats.clone();
+
+        let sender_task = tokio::spawn(async move {
+            let semaphore = Arc::new(Semaphore::new(worker_count));
+            let mut join_set = JoinSet::new();
+
+            while let Some(message) = receiver.recv().await {
+                let permit = semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .expect("should never be closed");
+
+                join_set.spawn(worker(
+                    client.clone(),
+                    timeout,
+                    message,
+                    permit,
+                    retry_sender.clone(),
+                    sender_stats.clone(),
+                    strategy,
+                ));
+            }
+
+            drop(retry_sender);
+
+            while !join_set.is_empty() {
+                join_set.join_next().await;
+            }
+        });
 
         Self {
-            senders,
-            handles,
-            reset_handle,
-            last_sender_idx: AtomicUsize::new(0),
             stats,
+            sender,
+            sender_task,
+            retry_sender_task,
         }
     }
+
     async fn queue(&self, message: SendActivityTask) -> Result<(), anyhow::Error> {
-        // really basic round-robin to our workers, we just do mod on the len of senders
-        let idx_to_send = self.last_sender_idx.fetch_add(1, Ordering::Relaxed) % self.senders.len();
-
-        // Set a queue to pending
         self.stats.pending.fetch_add(1, Ordering::Relaxed);
-
-        // Send to one of our workers
-        self.senders[idx_to_send].send(message)?;
+        self.sender.send(message)?;
 
         Ok(())
     }
@@ -339,18 +491,16 @@ impl ActivityQueue {
 
     #[allow(unused)]
     // Drops all the senders and shuts down the workers
-    async fn shutdown(self) -> Result<Stats, anyhow::Error> {
-        drop(self.senders);
+    async fn shutdown(self, wait_for_retries: bool) -> Result<Arc<Stats>, anyhow::Error> {
+        drop(self.sender);
 
-        // stop the reset counter task
-        self.reset_handle.abort();
-        self.reset_handle.await.ok();
+        self.sender_task.await?;
 
-        for handle in self.handles {
-            handle.await?;
+        if wait_for_retries {
+            self.retry_sender_task.await?;
         }
 
-        Arc::try_unwrap(self.stats).map_err(|_| anyhow!("Could not retrieve stats"))
+        Ok(self.stats)
     }
 }
 
@@ -359,38 +509,29 @@ impl ActivityQueue {
 pub(crate) fn create_activity_queue(
     client: ClientWithMiddleware,
     worker_count: usize,
+    retry_count: usize,
     request_timeout: Duration,
 ) -> ActivityQueue {
     assert!(
         worker_count > 0,
         "worker count needs to be greater than zero"
     );
-    /// We need to retry activity sending in case the target instances is temporarily unreachable.
-    /// In this case, the task is stored and resent when the instance is hopefully back up. This
-    /// list shows the retry intervals, and which events of the target instance can be covered:
-    /// - 60s (one minute, service restart)
-    /// - 60min (one hour, instance maintenance)
-    /// - 60h (2.5 days, major incident with rebuild from backup)
-    const MAX_RETRIES: usize = 3;
-    const BACKOFF: usize = 60;
 
-    ActivityQueue::new(
-        client,
-        worker_count,
-        request_timeout,
-        RetryStrategy {
-            backoff: BACKOFF,
-            retries: MAX_RETRIES,
-        },
-    )
+    ActivityQueue::new(client, worker_count, retry_count, request_timeout, 60)
 }
 
 /// Retries a future action factory function up to `amount` times with an exponential backoff timer between tries
-async fn retry<T, E: Display, F: Future<Output = Result<T, E>>, A: FnMut() -> F>(
+async fn retry<T, E: Display + Debug, F: Future<Output = Result<T, E>>, A: FnMut() -> F>(
     mut action: A,
     strategy: RetryStrategy,
 ) -> Result<T, E> {
-    let mut count = 0;
+    let mut count = strategy.offset;
+
+    // Do an initial sleep if it's called for
+    if strategy.initial_sleep > 0 {
+        let sleep_dur = Duration::from_secs(strategy.initial_sleep as u64);
+        tokio::time::sleep(sleep_dur).await;
+    }
 
     loop {
         match action().await {
@@ -401,7 +542,7 @@ async fn retry<T, E: Display, F: Future<Output = Result<T, E>>, A: FnMut() -> F>
 
                     let sleep_amt = strategy.backoff.pow(count as u32) as u64;
                     let sleep_dur = Duration::from_secs(sleep_amt);
-                    warn!("{err}.  Sleeping for {sleep_dur:?} and trying again");
+                    warn!("{err:?}.  Sleeping for {sleep_dur:?} and trying again");
                     tokio::time::sleep(sleep_dur).await;
                     continue;
                 } else {
@@ -456,7 +597,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    // Queues 10_000 messages and then asserts that the worker runs them
+    // Queues 100 messages and then asserts that the worker runs them
     async fn test_activity_queue_workers() {
         let num_workers = 64;
         let num_messages: usize = 100;
@@ -472,16 +613,15 @@ mod tests {
             .filter_module("activitypub_federation", LevelFilter::Info)
             .format_timestamp(None)
             .init();
+
         */
 
         let activity_queue = ActivityQueue::new(
             reqwest::Client::default().into(),
             num_workers,
+            num_workers,
             Duration::from_secs(10),
-            RetryStrategy {
-                backoff: 1,
-                retries: 3,
-            },
+            1,
         );
 
         let keypair = generate_actor_keypair().unwrap();
@@ -503,7 +643,7 @@ mod tests {
 
         info!("Queue Sent: {:?}", start.elapsed());
 
-        let stats = activity_queue.shutdown().await.unwrap();
+        let stats = activity_queue.shutdown(true).await.unwrap();
 
         info!(
             "Queue Finished.  Num msgs: {}, Time {:?}, msg/s: {:0.0}",

--- a/src/activity_queue.rs
+++ b/src/activity_queue.rs
@@ -329,7 +329,7 @@ impl ActivityQueue {
             handle.await?;
         }
 
-        Arc::into_inner(self.stats).ok_or_else(|| anyhow!("Could not retrieve stats"))
+        Arc::try_unwrap(self.stats).map_err(|_| anyhow!("Could not retrieve stats"))
     }
 }
 

--- a/src/actix_web/inbox.rs
+++ b/src/actix_web/inbox.rs
@@ -65,7 +65,7 @@ mod test {
     use reqwest_middleware::ClientWithMiddleware;
     use url::Url;
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn test_receive_activity() {
         let (body, incoming_request, config) = setup_receive_test().await;
         receive_activity::<Follow, DbUser, DbConnection>(
@@ -77,7 +77,7 @@ mod test {
         .unwrap();
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn test_receive_activity_invalid_body_signature() {
         let (_, incoming_request, config) = setup_receive_test().await;
         let err = receive_activity::<Follow, DbUser, DbConnection>(
@@ -93,7 +93,7 @@ mod test {
         assert_eq!(e, &Error::ActivityBodyDigestInvalid)
     }
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn test_receive_activity_invalid_path() {
         let (body, incoming_request, config) = setup_receive_test().await;
         let incoming_request = incoming_request.uri("/wrong");
@@ -125,7 +125,7 @@ mod test {
         let body = serde_json::to_string(&activity).unwrap();
         let outgoing_request = sign_request(
             request_builder,
-            activity.actor.into_inner(),
+            &activity.actor.into_inner(),
             body.to_string(),
             DB_USER_KEYPAIR.private_key.clone(),
             false,
@@ -142,6 +142,7 @@ mod test {
             .app_data(DbConnection)
             .debug(true)
             .build()
+            .await
             .unwrap();
         (body, incoming_request, config)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -195,7 +195,6 @@ impl<T: Clone> FederationConfigBuilder<T> {
             config.client.clone(),
             config.worker_count,
             config.request_timeout,
-            config.debug,
         );
         config.activity_queue = Some(Arc::new(queue));
         Ok(config)

--- a/src/fetch/collection_id.rs
+++ b/src/fetch/collection_id.rs
@@ -30,7 +30,7 @@ where
 
     /// Fetches collection over HTTP
     ///
-    /// Unlike [ObjectId::fetch](crate::fetch::object_id::ObjectId::fetch) this method doesn't do
+    /// Unlike [ObjectId::dereference](crate::fetch::object_id::ObjectId::dereference) this method doesn't do
     /// any caching.
     pub async fn dereference(
         &self,

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -56,7 +56,7 @@ pub async fn fetch_object_http<T: Clone, Kind: DeserializeOwned>(
     let res = if let Some((actor_id, private_key_pem)) = config.signed_fetch_actor.as_deref() {
         let req = sign_request(
             req,
-            actor_id.clone(),
+            actor_id,
             String::new(),
             private_key_pem.clone(),
             data.config.http_signature_compat,

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     reqwest_shim::ResponseExt,
     FEDERATION_CONTENT_TYPE,
 };
+use bytes::Bytes;
 use http::StatusCode;
 use serde::de::DeserializeOwned;
 use std::sync::atomic::Ordering;
@@ -57,7 +58,7 @@ pub async fn fetch_object_http<T: Clone, Kind: DeserializeOwned>(
         let req = sign_request(
             req,
             actor_id,
-            String::new(),
+            Bytes::new(),
             private_key_pem.clone(),
             data.config.http_signature_compat,
         )

--- a/src/fetch/object_id.rs
+++ b/src/fetch/object_id.rs
@@ -36,13 +36,12 @@ where
 /// # use activitypub_federation::config::FederationConfig;
 /// # use activitypub_federation::error::Error::NotFound;
 /// # use activitypub_federation::traits::tests::{DbConnection, DbUser};
-/// # let _ = actix_rt::System::new();
-/// # actix_rt::Runtime::new().unwrap().block_on(async {
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
 /// # let db_connection = DbConnection;
 /// let config = FederationConfig::builder()
 ///     .domain("example.com")
 ///     .app_data(db_connection)
-///     .build()?;
+///     .build().await?;
 /// let request_data = config.to_request_data();
 /// let object_id = ObjectId::<DbUser>::parse("https://lemmy.ml/u/nutomic")?;
 /// // Attempt to fetch object from local database or fall back to remote server

--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -199,12 +199,13 @@ mod tests {
         traits::tests::{DbConnection, DbUser},
     };
 
-    #[actix_rt::test]
+    #[tokio::test]
     async fn test_webfinger() {
         let config = FederationConfig::builder()
             .domain("example.com")
             .app_data(DbConnection)
             .build()
+            .await
             .unwrap();
         let data = config.to_request_data();
         let res =


### PR DESCRIPTION
This removes the `background-jobs` crate and replaces it with an inline activity queue that spawns tokio tasks to handle the background queue.  

I haven't given this a good test yet, as it doesn't appear very easy to benchmark/stress test the activity queue out, so would be interested in thoughts there.

This could be built into something with a bit more persistence in the future & generalise on the task submission.

Resolves https://github.com/LemmyNet/activitypub-federation-rust/issues/38 & https://github.com/LemmyNet/activitypub-federation-rust/issues/32

