### PR TITLE
Add a no limit option to the config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -56,14 +56,14 @@ pub struct FederationConfig<T: Clone> {
     /// like log tracing or retry of failed requests.
     pub(crate) client: ClientWithMiddleware,
     /// Number of tasks that can be in-flight concurrently.
-    /// Tasks are retried once after a minute, then put into the retry queue
-    /// Setting this count to `0` means that there is no limit
-    #[builder(default = "1024")]
+    /// Tasks are retried once after a minute, then put into the retry queue.
+    /// Setting this count to `0` means that there is no limit to concurrency
+    #[builder(default = "0")]
     pub(crate) worker_count: usize,
     /// Number of concurrent tasks that are being retried in-flight concurrently.
     /// Tasks are retried after an hour, then again in 60 hours.
-    /// Setting this count to `0` means that there is no limit
-    #[builder(default = "128")]
+    /// Setting this count to `0` means that there is no limit to concurrency
+    #[builder(default = "0")]
     pub(crate) retry_count: usize,
     /// Run library in debug mode. This allows usage of http and localhost urls. It also sends
     /// outgoing activities synchronously, not in background thread. This helps to make tests

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,10 +57,12 @@ pub struct FederationConfig<T: Clone> {
     pub(crate) client: ClientWithMiddleware,
     /// Number of tasks that can be in-flight concurrently.
     /// Tasks are retried once after a minute, then put into the retry queue
+    /// Setting this count to `0` means that there is no limit
     #[builder(default = "1024")]
     pub(crate) worker_count: usize,
     /// Number of concurrent tasks that are being retried in-flight concurrently.
     /// Tasks are retried after an hour, then again in 60 hours.
+    /// Setting this count to `0` means that there is no limit
     #[builder(default = "128")]
     pub(crate) retry_count: usize,
     /// Run library in debug mode. This allows usage of http and localhost urls. It also sends


### PR DESCRIPTION
This is an extension to an earlier PR which allows you to set the retry & worker counts to `0` to have basically unlimited tasks.  This does mean that if the server can't keep up with the outgoing requests then it will probably hit RAM limits (i.e, out of memory will occur).