### PR TITLE
Addressing persistent storage for activity queue

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@
 //! ```
 
 use crate::{
-    activity_queue::{create_activity_queue, ActivityQueue},
+    activity_queue::{create_activity_queue, ActivityQueue, DefaultStorageHandler, StorageInterface},
     error::Error,
     protocol::verification::verify_domains_match,
     traits::{ActivityHandler, Actor},
@@ -92,6 +92,11 @@ pub struct FederationConfig<T: Clone> {
     /// present once constructed.
     #[builder(setter(skip))]
     pub(crate) activity_queue: Option<Arc<ActivityQueue>>,
+
+    /// Implements the StorageInterface trait which provides an interface for 
+    /// storing objects and removing objects when appropiate
+    #[builder(default = "Box::new(DefaultStorageHandler())")]
+    pub(crate) outbound_storage: Box<dyn StorageInterface + Sync>,
 }
 
 impl<T: Clone> FederationConfig<T> {


### PR DESCRIPTION
This is a draft PR which attempts to address #31. There are still some TODOs and I am also looking for any feedback on the current method I am using

TODO:
- Formatting
- Prevent duplicates from being sent
- Determine who should handle recovery after a crash, and how that should be done
- Delete the Send Requests on disk after use
- Log errors returned by the potential database interface as opposed to ignoring them
- Actually test the code