### PR TITLE
fix: make "other" error actually transparent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ axum = { version = "0.6.18", features = [
 ], default-features = false, optional = true }
 tower = { version = "0.4.13", optional = true }
 hyper = { version = "0.14", optional = true }
-displaydoc = "0.2.4"
 
 [features]
 default = ["actix-web", "axum"]

--- a/examples/live_federation/objects/post.rs
+++ b/examples/live_federation/objects/post.rs
@@ -1,9 +1,6 @@
 use crate::{
-    activities::create_post::CreatePost,
-    database::DatabaseHandle,
-    error::Error,
-    generate_object_id,
-    objects::person::DbUser,
+    activities::create_post::CreatePost, database::DatabaseHandle, error::Error,
+    generate_object_id, objects::person::DbUser,
 };
 use activitypub_federation::{
     config::Data,

--- a/examples/local_federation/activities/accept.rs
+++ b/examples/local_federation/activities/accept.rs
@@ -1,9 +1,6 @@
 use crate::{activities::follow::Follow, instance::DatabaseHandle, objects::person::DbUser};
 use activitypub_federation::{
-    config::Data,
-    fetch::object_id::ObjectId,
-    kinds::activity::AcceptType,
-    traits::ActivityHandler,
+    config::Data, fetch::object_id::ObjectId, kinds::activity::AcceptType, traits::ActivityHandler,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/examples/local_federation/activities/follow.rs
+++ b/examples/local_federation/activities/follow.rs
@@ -1,7 +1,5 @@
 use crate::{
-    activities::accept::Accept,
-    generate_object_id,
-    instance::DatabaseHandle,
+    activities::accept::Accept, generate_object_id, instance::DatabaseHandle,
     objects::person::DbUser,
 };
 use activitypub_federation::{

--- a/examples/local_federation/axum/http.rs
+++ b/examples/local_federation/axum/http.rs
@@ -17,8 +17,7 @@ use axum::{
     extract::{Path, Query},
     response::IntoResponse,
     routing::{get, post},
-    Json,
-    Router,
+    Json, Router,
 };
 use axum_macros::debug_handler;
 use serde::Deserialize;

--- a/src/activity_queue.rs
+++ b/src/activity_queue.rs
@@ -77,14 +77,14 @@ where
         .unique()
         .filter(|i| !config.is_local_url(i))
         .collect();
-
     // This field is only optional to make builder work, its always present at this point
     let activity_queue = config
         .activity_queue
         .as_ref()
         .expect("Config has activity queue");
     for inbox in inboxes {
-        if config.verify_url_valid(&inbox).await.is_err() {
+        if let Err(err) = config.verify_url_valid(&inbox).await {
+            debug!("inbox url invalid, skipping: {inbox}: {err}");
             continue;
         }
 

--- a/src/activity_queue.rs
+++ b/src/activity_queue.rs
@@ -10,7 +10,7 @@ use crate::{
     traits::{ActivityHandler, Actor},
     FEDERATION_CONTENT_TYPE,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 
 use bytes::Bytes;
 use futures_core::Future;
@@ -166,7 +166,8 @@ async fn sign_and_send(
         task.private_key.clone(),
         task.http_signature_compat,
     )
-    .await?;
+    .await
+    .context("signing request")?;
 
     retry(
         || {

--- a/src/actix_web/inbox.rs
+++ b/src/actix_web/inbox.rs
@@ -8,6 +8,7 @@ use crate::{
     traits::{ActivityHandler, Actor, Object},
 };
 use actix_web::{web::Bytes, HttpRequest, HttpResponse};
+use anyhow::Context;
 use serde::de::DeserializeOwned;
 use tracing::debug;
 

--- a/src/actix_web/inbox.rs
+++ b/src/actix_web/inbox.rs
@@ -33,7 +33,8 @@ where
 {
     verify_body_hash(request.headers().get("Digest"), &body)?;
 
-    let activity: Activity = serde_json::from_slice(&body)?;
+    let activity: Activity = serde_json::from_slice(&body)
+        .with_context(|| format!("deserializing body: {}", String::from_utf8_lossy(&body)))?;
     data.config.verify_url_and_domain(&activity).await?;
     let actor = ObjectId::<ActorT>::from(activity.actor().clone())
         .dereference(data)

--- a/src/actix_web/middleware.rs
+++ b/src/actix_web/middleware.rs
@@ -1,10 +1,7 @@
 use crate::config::{Data, FederationConfig, FederationMiddleware};
 use actix_web::{
     dev::{forward_ready, Payload, Service, ServiceRequest, ServiceResponse, Transform},
-    Error,
-    FromRequest,
-    HttpMessage,
-    HttpRequest,
+    Error, FromRequest, HttpMessage, HttpRequest,
 };
 use std::future::{ready, Ready};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,27 +1,33 @@
 //! Error messages returned by this library
 
-use displaydoc::Display;
-
 /// Error messages returned by this library
-#[derive(thiserror::Error, Debug, Display)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// Object was not found in local database
+    #[error("Object was not found in local database")]
     NotFound,
     /// Request limit was reached during fetch
+    #[error("Request limit was reached during fetch")]
     RequestLimit,
     /// Response body limit was reached during fetch
+    #[error("Response body limit was reached during fetch")]
     ResponseBodyLimit,
     /// Object to be fetched was deleted
+    #[error("Object to be fetched was deleted")]
     ObjectDeleted,
-    /// {0}
+    /// url verification error
+    #[error("{0}")]
     UrlVerificationError(&'static str),
     /// Incoming activity has invalid digest for body
+    #[error("Incoming activity has invalid digest for body")]
     ActivityBodyDigestInvalid,
     /// Incoming activity has invalid signature
+    #[error("Incoming activity has invalid signature")]
     ActivitySignatureInvalid,
     /// Failed to resolve actor via webfinger
+    #[error("Failed to resolve actor via webfinger")]
     WebfingerResolveFailed,
-    /// Other errors which are not explicitly handled
+    /// other error
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -3,10 +3,7 @@
 #![doc = include_str!("../../docs/07_fetching_data.md")]
 
 use crate::{
-    config::Data,
-    error::Error,
-    http_signatures::sign_request,
-    reqwest_shim::ResponseExt,
+    config::Data, error::Error, http_signatures::sign_request, reqwest_shim::ResponseExt,
     FEDERATION_CONTENT_TYPE,
 };
 use bytes::Bytes;


### PR DESCRIPTION
This PR fixes the Display trait for the "Other" error. Before, these errors would just output "Other errors which are not explicitly handled" for everything without any other context.
with this change, they output the full anyhow content.

e.g.: "data did not match any variant of untagged enum PersonOrGroup"

or: "Request error: error sending request for url (http://localhost:5313/u/Lady_Albedo_96): connection error: Connection reset by peer (os error 104)"


The reason for this issue was some bad interaction between the "displaydoc" library and the "thiserror" library. I tried a few other things to fix it but nothing except removing DisplayDoc worked.

This PR also adds a few random "context" calls that I needed while debugging something. They aren't great but imo the more anyhow context is used the better.