### PR TITLE
add shutdown method

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -5,14 +5,14 @@ pipeline:
       - /root/.cargo/bin/cargo fmt -- --check
 
   cargo_check:
-    image: rust:1.65-bullseye
+    image: rust:1.70-bullseye
     environment:
       CARGO_HOME: .cargo
     commands:
       - cargo check --all-features --all-targets
 
   cargo_clippy:
-    image: rust:1.65-bullseye
+    image: rust:1.70-bullseye
     environment:
       CARGO_HOME: .cargo
     commands:
@@ -26,28 +26,28 @@ pipeline:
       - cargo clippy --all-features -- -D clippy::unwrap_used
 
   cargo_test:
-    image: rust:1.65-bullseye
+    image: rust:1.70-bullseye
     environment:
       CARGO_HOME: .cargo
     commands:
       - cargo test --all-features --no-fail-fast
 
   cargo_doc:
-    image: rust:1.65-bullseye
+    image: rust:1.70-bullseye
     environment:
       CARGO_HOME: .cargo
     commands:
       - cargo doc --all-features
 
   cargo_run_actix_example:
-    image: rust:1.65-bullseye
+    image: rust:1.70-bullseye
     environment:
       CARGO_HOME: .cargo
     commands:
       - cargo run --example local_federation actix-web
 
   cargo_run_axum_example:
-    image: rust:1.65-bullseye
+    image: rust:1.70-bullseye
     environment:
       CARGO_HOME: .cargo
     commands:

--- a/src/config.rs
+++ b/src/config.rs
@@ -204,7 +204,7 @@ impl<T: Clone> FederationConfig<T> {
             })?
             .shutdown(wait_retries)
             .await?;
-        return Ok(stats);
+        Ok(stats)
     }
 }
 

--- a/src/fetch/object_id.rs
+++ b/src/fetch/object_id.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 impl<T> FromStr for ObjectId<T>
 where
-    T: Object + Send + 'static,
+    T: Object + Send + Debug + 'static,
     for<'de2> <T as Object>::Kind: Deserialize<'de2>,
 {
     type Err = url::ParseError;
@@ -62,7 +62,7 @@ where
 
 impl<Kind> ObjectId<Kind>
 where
-    Kind: Object + Send + 'static,
+    Kind: Object + Send + Debug + 'static,
     for<'de2> <Kind as Object>::Kind: serde::Deserialize<'de2>,
 {
     /// Construct a new objectid instance
@@ -93,7 +93,6 @@ where
         <Kind as Object>::Error: From<Error> + From<anyhow::Error>,
     {
         let db_object = self.dereference_from_db(data).await?;
-
         // if its a local object, only fetch it from the database and not over http
         if data.config.is_local_url(&self.0) {
             return match db_object {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -93,7 +93,7 @@ use url::Url;
 ///
 /// }
 #[async_trait]
-pub trait Object: Sized {
+pub trait Object: Sized + Debug {
     /// App data type passed to handlers. Must be identical to
     /// [crate::config::FederationConfigBuilder::app_data] type.
     type DataType: Clone + Send + Sync;


### PR DESCRIPTION
This adds a public shutdown method that shuts down the federation while waiting for the workers. This is useful because otherwise the queue is completely lost on shutdown.

I added this because I need it to benchmark federation performance, but it should probably be added to lemmy as well.

I also moved the print of Stats to the Debug impl since it's useful in other places.

Currently, shutdown only works correctly if worker_count is > 0, but that can be fixed separately.