### PR TITLE
implement simple moka cache for all dereference() calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ axum = { version = "0.6.18", features = [
 tower = { version = "0.4.13", optional = true }
 hyper = { version = "0.14", optional = true }
 moka = { version = "0.11.2", features = ["future"] }
+type-map = "0.5.0"
 
 [features]
 default = ["actix-web", "axum"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ axum = { version = "0.6.18", features = [
 ], default-features = false, optional = true }
 tower = { version = "0.4.13", optional = true }
 hyper = { version = "0.14", optional = true }
+moka = { version = "0.11.2", features = ["future"] }
 
 [features]
 default = ["actix-web", "axum"]

--- a/examples/live_federation/error.rs
+++ b/examples/live_federation/error.rs
@@ -1,8 +1,8 @@
-use std::fmt::{Display, Formatter};
+use std::{fmt::{Display, Formatter}, sync::Arc};
 
 /// Necessary because of this issue: https://github.com/actix/actix-web/issues/1711
-#[derive(Debug)]
-pub struct Error(pub(crate) anyhow::Error);
+#[derive(Debug, Clone)]
+pub struct Error(pub(crate) Arc<anyhow::Error>);
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -15,6 +15,6 @@ where
     T: Into<anyhow::Error>,
 {
     fn from(t: T) -> Self {
-        Error(t.into())
+        Error(Arc::new(t.into()))
     }
 }

--- a/examples/local_federation/error.rs
+++ b/examples/local_federation/error.rs
@@ -1,8 +1,8 @@
-use std::fmt::{Display, Formatter};
+use std::{fmt::{Display, Formatter}, sync::Arc};
 
 /// Necessary because of this issue: https://github.com/actix/actix-web/issues/1711
-#[derive(Debug)]
-pub struct Error(pub(crate) anyhow::Error);
+#[derive(Debug, Clone)]
+pub struct Error(pub(crate) Arc<anyhow::Error>);
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -15,6 +15,6 @@ where
     T: Into<anyhow::Error>,
 {
     fn from(t: T) -> Self {
-        Error(t.into())
+        Error(Arc::new(t.into()))
     }
 }

--- a/src/actix_web/inbox.rs
+++ b/src/actix_web/inbox.rs
@@ -22,13 +22,13 @@ pub async fn receive_activity<Activity, ActorT, Datatype>(
 ) -> Result<HttpResponse, <Activity as ActivityHandler>::Error>
 where
     Activity: ActivityHandler<DataType = Datatype> + DeserializeOwned + Send + 'static,
-    ActorT: Object<DataType = Datatype> + Actor + Send + 'static,
+    ActorT: Object<DataType = Datatype> + Actor + Clone + Sync + Send + 'static,
     for<'de2> <ActorT as Object>::Kind: serde::Deserialize<'de2>,
     <Activity as ActivityHandler>::Error: From<anyhow::Error>
         + From<Error>
         + From<<ActorT as Object>::Error>
         + From<serde_json::Error>,
-    <ActorT as Object>::Error: From<Error> + From<anyhow::Error>,
+    <ActorT as Object>::Error: From<Error> + From<anyhow::Error> + Clone + Send + Sync,
     Datatype: Clone,
 {
     verify_body_hash(request.headers().get("Digest"), &body)?;

--- a/src/actix_web/mod.rs
+++ b/src/actix_web/mod.rs
@@ -21,8 +21,8 @@ pub async fn signing_actor<A>(
     data: &Data<<A as Object>::DataType>,
 ) -> Result<A, <A as Object>::Error>
 where
-    A: Object + Actor,
-    <A as Object>::Error: From<Error> + From<anyhow::Error>,
+    A: Object + Actor + Sync + Send + Clone,
+    <A as Object>::Error: From<Error> + From<anyhow::Error> + Sync + Clone + Send,
     for<'de2> <A as Object>::Kind: Deserialize<'de2>,
 {
     verify_body_hash(request.headers().get("Digest"), &body.unwrap_or_default())?;

--- a/src/axum/inbox.rs
+++ b/src/axum/inbox.rs
@@ -27,13 +27,13 @@ pub async fn receive_activity<Activity, ActorT, Datatype>(
 ) -> Result<(), <Activity as ActivityHandler>::Error>
 where
     Activity: ActivityHandler<DataType = Datatype> + DeserializeOwned + Send + 'static,
-    ActorT: Object<DataType = Datatype> + Actor + Send + 'static,
+    ActorT: Object<DataType = Datatype> + Actor + Send + Sync + Clone + 'static,
     for<'de2> <ActorT as Object>::Kind: serde::Deserialize<'de2>,
     <Activity as ActivityHandler>::Error: From<anyhow::Error>
         + From<Error>
         + From<<ActorT as Object>::Error>
         + From<serde_json::Error>,
-    <ActorT as Object>::Error: From<Error> + From<anyhow::Error>,
+    <ActorT as Object>::Error: From<Error> + From<anyhow::Error> + Clone + Send + Sync,
     Datatype: Clone,
 {
     verify_body_hash(activity_data.headers.get("Digest"), &activity_data.body)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,9 @@ pub struct FederationConfig<T: Clone> {
     /// more consistent. Do not use for production.
     #[builder(default = "false")]
     pub(crate) debug: bool,
+    /// Allow HTTP urls even in production mode
+    #[builder(default = "self.debug.unwrap_or(false)")]
+    pub(crate) allow_http_urls: bool,
     /// Timeout for all HTTP requests. HTTP signatures are valid for 10s, so it makes sense to
     /// use the same as timeout when sending
     #[builder(default = "Duration::from_secs(10)")]
@@ -134,7 +137,7 @@ impl<T: Clone> FederationConfig<T> {
         match url.scheme() {
             "https" => {}
             "http" => {
-                if !self.debug {
+                if !self.allow_http_urls {
                     return Err(Error::UrlVerificationError(
                         "Http urls are only allowed in debug mode",
                     ));

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,6 @@ pub enum Error {
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
-
 impl Error {
     pub(crate) fn other<T>(error: T) -> Self
     where

--- a/src/http_signatures.rs
+++ b/src/http_signatures.rs
@@ -151,8 +151,8 @@ pub(crate) async fn signing_actor<'a, A, H>(
     data: &Data<<A as Object>::DataType>,
 ) -> Result<A, <A as Object>::Error>
 where
-    A: Object + Actor,
-    <A as Object>::Error: From<Error> + From<anyhow::Error>,
+    A: Object + Actor + Clone + Sync,
+    <A as Object>::Error: From<Error> + From<anyhow::Error> + Clone + Send + Sync,
     for<'de2> <A as Object>::Kind: Deserialize<'de2>,
     H: IntoIterator<Item = (&'a HeaderName, &'a HeaderValue)>,
 {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -93,7 +93,7 @@ use url::Url;
 ///
 /// }
 #[async_trait]
-pub trait Object: Sized {
+pub trait Object: Sized + core::fmt::Debug {
     /// App data type passed to handlers. Must be identical to
     /// [crate::config::FederationConfigBuilder::app_data] type.
     type DataType: Clone + Send + Sync;
@@ -108,7 +108,7 @@ pub trait Object: Sized {
     }
     /// Defines how long objects of this type should live in the in-memory cache
     fn cache_time_to_live() -> Duration {
-        Duration::from_secs(10)
+        Duration::from_secs(600)
     }
 
     /// Returns the last time this object was updated.


### PR DESCRIPTION
This PR caches the dereference() function in memory (so it caches both DB fetches as well as HTTP fetches). The cache is separate per object type is both limited by a time to live (default 10s) and by a object count (default 1000).

Since dereference() is a core mechanic of lemmy, this should improve performance of both normal api calls as well as incoming federation calls.

The main pain is that right now it means that both Object and the Object::Error type need to be Send + Sync + Clone (since they are stored in the cache and can thus be accessed from multiple places simultaneously). Send + Sync isn't causing any issues, but since anyhow::Error is not Clone, this requires some really annoying changes in the examples and making LemmyError Clone (by storing the inner anyhow::Error in an Arc).

The cache also prevents multiple concurrent db fetches and multiple concurrent HTTP requests to the same object as well as race conditions in other code resulting from it.

The following I'm still planning todo:

- some testing
- performance benchmarking (i was planning to do a simple comparison here)

Open questions:
- any approval / concerns with this approach
- should there be defaults for the cache count and duration? maybe not.
- what should the cache count and TTL duration values be for lemmy? are there places where this caching causes issue?
- There's now a ton of trait bounds that are passed around in 10 different places here and another 10 places in lemmy. Should just move all of those to the Object trait? They are only required for the dereference function (as before), but idk if there's actually any point to not having them on the main trait. Just look at that signature of the `receive_activity` function.