### PR TITLE
Fix regex error when actix-web feature not enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ bytes = "1.4.0"
 futures-core = { version = "0.3.28", default-features = false }
 pin-project-lite = "0.2.9"
 activitystreams-kinds = "0.3.0"
-regex = { version = "1.8.4", default-features = false, features = ["std"] }
+regex = { version = "1.8.4", default-features = false, features = ["std", "unicode-case"] }
 tokio = { version = "1.21.2", features = [
   "sync",
   "rt",

--- a/examples/live_federation/objects/post.rs
+++ b/examples/live_federation/objects/post.rs
@@ -1,6 +1,9 @@
 use crate::{
-    activities::create_post::CreatePost, database::DatabaseHandle, error::Error,
-    generate_object_id, objects::person::DbUser,
+    activities::create_post::CreatePost,
+    database::DatabaseHandle,
+    error::Error,
+    generate_object_id,
+    objects::person::DbUser,
 };
 use activitypub_federation::{
     config::Data,

--- a/examples/local_federation/activities/accept.rs
+++ b/examples/local_federation/activities/accept.rs
@@ -1,6 +1,9 @@
 use crate::{activities::follow::Follow, instance::DatabaseHandle, objects::person::DbUser};
 use activitypub_federation::{
-    config::Data, fetch::object_id::ObjectId, kinds::activity::AcceptType, traits::ActivityHandler,
+    config::Data,
+    fetch::object_id::ObjectId,
+    kinds::activity::AcceptType,
+    traits::ActivityHandler,
 };
 use serde::{Deserialize, Serialize};
 use url::Url;

--- a/examples/local_federation/activities/follow.rs
+++ b/examples/local_federation/activities/follow.rs
@@ -1,5 +1,7 @@
 use crate::{
-    activities::accept::Accept, generate_object_id, instance::DatabaseHandle,
+    activities::accept::Accept,
+    generate_object_id,
+    instance::DatabaseHandle,
     objects::person::DbUser,
 };
 use activitypub_federation::{

--- a/examples/local_federation/axum/http.rs
+++ b/examples/local_federation/axum/http.rs
@@ -17,7 +17,8 @@ use axum::{
     extract::{Path, Query},
     response::IntoResponse,
     routing::{get, post},
-    Json, Router,
+    Json,
+    Router,
 };
 use axum_macros::debug_handler;
 use serde::Deserialize;

--- a/src/actix_web/middleware.rs
+++ b/src/actix_web/middleware.rs
@@ -1,7 +1,10 @@
 use crate::config::{Data, FederationConfig, FederationMiddleware};
 use actix_web::{
     dev::{forward_ready, Payload, Service, ServiceRequest, ServiceResponse, Transform},
-    Error, FromRequest, HttpMessage, HttpRequest,
+    Error,
+    FromRequest,
+    HttpMessage,
+    HttpRequest,
 };
 use std::future::{ready, Ready};
 

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -3,7 +3,10 @@
 #![doc = include_str!("../../docs/07_fetching_data.md")]
 
 use crate::{
-    config::Data, error::Error, http_signatures::sign_request, reqwest_shim::ResponseExt,
+    config::Data,
+    error::Error,
+    http_signatures::sign_request,
+    reqwest_shim::ResponseExt,
     FEDERATION_CONTENT_TYPE,
 };
 use bytes::Bytes;

--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -66,6 +66,25 @@ where
 /// request. For a parameter of the form `acct:gargron@mastodon.social` it returns `gargron`.
 ///
 /// Returns an error if query doesn't match local domain.
+///
+///```
+/// # use activitypub_federation::config::FederationConfig;
+/// # use activitypub_federation::traits::tests::DbConnection;
+/// # use activitypub_federation::fetch::webfinger::extract_webfinger_name;
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// # let db_connection = DbConnection;
+/// let config = FederationConfig::builder()
+///     .domain("example.com")
+///     .app_data(db_connection)
+///     .build()
+///     .await
+///     .unwrap();
+/// let data = config.to_request_data();
+/// let res = extract_webfinger_name("acct:test_user@example.com", &data).unwrap();
+/// assert_eq!(res, "test_user");
+/// # Ok::<(), anyhow::Error>(())
+/// }).unwrap();
+///```
 pub fn extract_webfinger_name<T>(query: &str, data: &Data<T>) -> Result<String, Error>
 where
     T: Clone,


### PR DESCRIPTION
If the crate is built with only the axum feature, compiling the webfinger account regex will fail with an error "Unicode-aware case insensitivity matching is not available..." because of the missing unicode-case feature. This doesn't happen if actix is installed because it pulls in the regex crate with all features (via [actix-router][0]).

The failure can be demonstrated by reverting this commit's change to Cargo.toml and running:

    cargo test --no-default-features --features=axum --doc extract_webfinger_name

Resolve this by adding the unicode-case feature to the regex dependency.

[0]: https://github.com/actix/actix-web/blob/0e8ed50e3a7ac93d94e6c1c6603d0048e1f33fb8/actix-router/Cargo.toml#L25