### PR TITLE
Use anyhow::Error for UrlVerifier return type (fixes #61)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ axum-macros = "0.3.7"
 tokio = { version = "1.21.2", features = ["full"] }
 
 [profile.dev]
-#strip = "symbols"
-#debug = 0
+strip = "symbols"
+debug = 0
 
 [[example]]
 name = "local_federation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ axum-macros = "0.3.7"
 tokio = { version = "1.21.2", features = ["full"] }
 
 [profile.dev]
-strip = "symbols"
-debug = 0
+#strip = "symbols"
+#debug = 0
 
 [[example]]
 name = "local_federation"

--- a/examples/local_federation/instance.rs
+++ b/examples/local_federation/instance.rs
@@ -49,9 +49,9 @@ struct MyUrlVerifier();
 
 #[async_trait]
 impl UrlVerifier for MyUrlVerifier {
-    async fn verify(&self, url: &Url) -> Result<(), &'static str> {
+    async fn verify(&self, url: &Url) -> Result<(), anyhow::Error> {
         if url.domain() == Some("malicious.com") {
-            Err("malicious domain")
+            Err(anyhow!("malicious domain"))
         } else {
             Ok(())
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,9 +114,9 @@ impl<T: Clone> FederationConfig<T> {
         verify_domains_match(activity.id(), activity.actor())?;
         self.verify_url_valid(activity.id()).await?;
         if self.is_local_url(activity.id()) {
-            return Err(Error::UrlVerificationError(
-                anyhow!("Activity was sent from local instance"),
-            ));
+            return Err(Error::UrlVerificationError(anyhow!(
+                "Activity was sent from local instance"
+            )));
         }
 
         Ok(())
@@ -139,9 +139,9 @@ impl<T: Clone> FederationConfig<T> {
             "https" => {}
             "http" => {
                 if !self.allow_http_urls {
-                    return Err(Error::UrlVerificationError(
-                        anyhow!("Http urls are only allowed in debug mode"),
-                    ));
+                    return Err(Error::UrlVerificationError(anyhow!(
+                        "Http urls are only allowed in debug mode"
+                    )));
                 }
             }
             _ => return Err(Error::UrlVerificationError(anyhow!("Invalid url scheme"))),
@@ -153,13 +153,15 @@ impl<T: Clone> FederationConfig<T> {
         }
 
         if url.domain().is_none() {
-            return Err(Error::UrlVerificationError(anyhow!("Url must have a domain")));
+            return Err(Error::UrlVerificationError(anyhow!(
+                "Url must have a domain"
+            )));
         }
 
         if url.domain() == Some("localhost") && !self.debug {
-            return Err(Error::UrlVerificationError(
-                anyhow!("Localhost is only allowed in debug mode"),
-            ));
+            return Err(Error::UrlVerificationError(anyhow!(
+                "Localhost is only allowed in debug mode"
+            )));
         }
 
         self.url_verifier

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,8 +16,8 @@ pub enum Error {
     #[error("Object to be fetched was deleted")]
     ObjectDeleted,
     /// url verification error
-    #[error("{0}")]
-    UrlVerificationError(&'static str),
+    #[error("URL failed verification: {0}")]
+    UrlVerificationError(anyhow::Error),
     /// Incoming activity has invalid digest for body
     #[error("Incoming activity has invalid digest for body")]
     ActivityBodyDigestInvalid,

--- a/src/protocol/verification.rs
+++ b/src/protocol/verification.rs
@@ -1,7 +1,7 @@
 //! Verify that received data is valid
 
+use crate::error::Error;
 use anyhow::anyhow;
-use crate::error::{Error};
 use url::Url;
 
 /// Check that both urls have the same domain. If not, return UrlVerificationError.

--- a/src/protocol/verification.rs
+++ b/src/protocol/verification.rs
@@ -1,6 +1,7 @@
 //! Verify that received data is valid
 
-use crate::error::Error;
+use anyhow::anyhow;
+use crate::error::{Error};
 use url::Url;
 
 /// Check that both urls have the same domain. If not, return UrlVerificationError.
@@ -15,7 +16,7 @@ use url::Url;
 /// ```
 pub fn verify_domains_match(a: &Url, b: &Url) -> Result<(), Error> {
     if a.domain() != b.domain() {
-        return Err(Error::UrlVerificationError("Domains do not match"));
+        return Err(Error::UrlVerificationError(anyhow!("Domains do not match")));
     }
     Ok(())
 }
@@ -32,7 +33,7 @@ pub fn verify_domains_match(a: &Url, b: &Url) -> Result<(), Error> {
 /// ```
 pub fn verify_urls_match(a: &Url, b: &Url) -> Result<(), Error> {
     if a != b {
-        return Err(Error::UrlVerificationError("Urls do not match"));
+        return Err(Error::UrlVerificationError(anyhow!("Urls do not match")));
     }
     Ok(())
 }


### PR DESCRIPTION
This will allow returning LemmyErrorType from [check_apub_id_valid](https://github.com/LemmyNet/lemmy/blob/error-enum-fixed/crates/apub/src/lib.rs#L65) and avoid this ugly workaround:

https://github.com/LemmyNet/lemmy/blob/error-enum-fixed/crates/apub/src/lib.rs#L148-L153