### PR TITLE
Increase fetch_object max body size

### DIFF
--- a/src/reqwest_shim.rs
+++ b/src/reqwest_shim.rs
@@ -12,8 +12,8 @@ use std::{
     task::{Context, Poll},
 };
 
-/// 100KB
-const MAX_BODY_SIZE: usize = 102400;
+/// 200KB
+const MAX_BODY_SIZE: usize = 204800;
 
 pin_project! {
     pub struct BytesFuture {


### PR DESCRIPTION
Increase max body size for HTTP requests. The current limit is too low and results in an error when fetching `https://lemmy.ml/c/degoogle/outbox` which has 125014 bytes.