### PR TITLE
Support fetches with redirect

### DIFF
--- a/src/fetch/collection_id.rs
+++ b/src/fetch/collection_id.rs
@@ -40,9 +40,10 @@ where
     where
         <Kind as Collection>::Error: From<Error>,
     {
-        let json = fetch_object_http(&self.0, data).await?;
-        Kind::verify(&json, &self.0, data).await?;
-        Kind::from_json(json, owner, data).await
+        let res = fetch_object_http(&self.0, data).await?;
+        let redirect_url = &res.url;
+        Kind::verify(&res.object, redirect_url, data).await?;
+        Kind::from_json(res.object, owner, data).await
     }
 }
 

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -26,9 +26,9 @@ pub mod webfinger;
 /// Response from fetching a remote object
 pub struct FetchObjectResponse<Kind> {
     /// The resolved object
-    object: Kind,
+    pub object: Kind,
     /// Contains the final URL (different from request URL in case of redirect)
-    url: Url,
+    pub url: Url,
 }
 
 /// Fetch a remote object over HTTP and convert to `Kind`.
@@ -95,6 +95,6 @@ async fn fetch_object_http_with_accept<T: Clone, Kind: DeserializeOwned>(
     let url = res.url().clone();
     Ok(FetchObjectResponse {
         object: res.json_limited().await?,
-        url
+        url,
     })
 }

--- a/src/fetch/object_id.rs
+++ b/src/fetch/object_id.rs
@@ -156,10 +156,11 @@ where
             return Err(anyhow!("Fetched remote object {} which was deleted", self).into());
         }
 
-        let res2 = res?;
+        let res = res?;
+        let redirect_url = &res.url;
 
-        Kind::verify(&res2, self.inner(), data).await?;
-        Kind::from_json(res2, data).await
+        Kind::verify(&res.object, redirect_url, data).await?;
+        Kind::from_json(res.object, data).await
     }
 }
 

--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -38,7 +38,7 @@ where
 
     let res: Webfinger =
         fetch_object_http_with_accept(&Url::parse(&fetch_url)?, data, "application/jrd+json")
-            .await?;
+            .await?.object;
 
     debug_assert_eq!(res.subject, format!("acct:{identifier}"));
     let links: Vec<Url> = res

--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -38,7 +38,8 @@ where
 
     let res: Webfinger =
         fetch_object_http_with_accept(&Url::parse(&fetch_url)?, data, "application/jrd+json")
-            .await?.object;
+            .await?
+            .object;
 
     debug_assert_eq!(res.subject, format!("acct:{identifier}"));
     let links: Vec<Url> = res


### PR DESCRIPTION
When fetching a URL with redirect, return the final URL and use that for verification instead of the original URL. Necessary for https://github.com/LemmyNet/lemmy/pull/4073. However this might cause some security problems, not sure.