### PR TITLE
Remove `anyhow` from trait definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ serde = { version = "1.0.189", features = ["derive"] }
 async-trait = "0.1.74"
 url = { version = "2.4.1", features = ["serde"] }
 serde_json = { version = "1.0.107", features = ["preserve_order"] }
-anyhow = "1.0.75"
 reqwest = { version = "0.11.22", features = ["json", "stream"] }
 reqwest-middleware = "0.2.3"
 tracing = "0.1.40"
@@ -65,6 +64,7 @@ actix-web = ["dep:actix-web"]
 axum = ["dep:axum", "dep:tower", "dep:hyper"]
 
 [dev-dependencies]
+anyhow = "1.0.75"
 rand = "0.8.5"
 env_logger = "0.10.0"
 tower-http = { version = "0.4.4", features = ["map-request-body", "util"] }

--- a/examples/local_federation/instance.rs
+++ b/examples/local_federation/instance.rs
@@ -49,9 +49,11 @@ struct MyUrlVerifier();
 
 #[async_trait]
 impl UrlVerifier for MyUrlVerifier {
-    async fn verify(&self, url: &Url) -> Result<(), anyhow::Error> {
+    async fn verify(&self, url: &Url) -> Result<(), activitypub_federation::error::Error> {
         if url.domain() == Some("malicious.com") {
-            Err(anyhow!("malicious domain"))
+            Err(activitypub_federation::error::Error::Other(
+                "malicious domain".into(),
+            ))
         } else {
             Ok(())
         }

--- a/examples/local_federation/objects/person.rs
+++ b/examples/local_federation/objects/person.rs
@@ -107,7 +107,7 @@ impl DbUser {
         activity: Activity,
         recipients: Vec<Url>,
         data: &Data<DatabaseHandle>,
-    ) -> Result<(), <Activity as ActivityHandler>::Error>
+    ) -> Result<(), Error>
     where
         Activity: ActivityHandler + Serialize + Debug + Send + Sync,
         <Activity as ActivityHandler>::Error: From<anyhow::Error> + From<serde_json::Error>,

--- a/src/actix_web/mod.rs
+++ b/src/actix_web/mod.rs
@@ -22,7 +22,7 @@ pub async fn signing_actor<A>(
 ) -> Result<A, <A as Object>::Error>
 where
     A: Object + Actor,
-    <A as Object>::Error: From<Error> + From<anyhow::Error>,
+    <A as Object>::Error: From<Error>,
     for<'de2> <A as Object>::Kind: Deserialize<'de2>,
 {
     verify_body_hash(request.headers().get("Digest"), &body.unwrap_or_default())?;

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -83,13 +83,13 @@ async fn fetch_object_http_with_accept<T: Clone, Kind: DeserializeOwned>(
             data.config.http_signature_compat,
         )
         .await?;
-        config.client.execute(req).await.map_err(Error::other)?
+        config.client.execute(req).await?
     } else {
-        req.send().await.map_err(Error::other)?
+        req.send().await?
     };
 
     if res.status() == StatusCode::GONE {
-        return Err(Error::ObjectDeleted);
+        return Err(Error::ObjectDeleted(url.clone()));
     }
 
     let url = res.url().clone();

--- a/src/fetch/object_id.rs
+++ b/src/fetch/object_id.rs
@@ -1,5 +1,4 @@
 use crate::{config::Data, error::Error, fetch::fetch_object_http, traits::Object};
-use anyhow::anyhow;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -90,7 +89,7 @@ where
         data: &Data<<Kind as Object>::DataType>,
     ) -> Result<Kind, <Kind as Object>::Error>
     where
-        <Kind as Object>::Error: From<Error> + From<anyhow::Error>,
+        <Kind as Object>::Error: From<Error>,
     {
         let db_object = self.dereference_from_db(data).await?;
         // if its a local object, only fetch it from the database and not over http
@@ -145,15 +144,15 @@ where
         db_object: Option<Kind>,
     ) -> Result<Kind, <Kind as Object>::Error>
     where
-        <Kind as Object>::Error: From<Error> + From<anyhow::Error>,
+        <Kind as Object>::Error: From<Error>,
     {
         let res = fetch_object_http(&self.0, data).await;
 
-        if let Err(Error::ObjectDeleted) = &res {
+        if let Err(Error::ObjectDeleted(url)) = res {
             if let Some(db_object) = db_object {
                 db_object.delete(data).await?;
             }
-            return Err(anyhow!("Fetched remote object {} which was deleted", self).into());
+            return Err(Error::ObjectDeleted(url).into());
         }
 
         let res = res?;

--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -5,7 +5,6 @@ use crate::{
     traits::{Actor, Object},
     FEDERATION_CONTENT_TYPE,
 };
-use anyhow::anyhow;
 use itertools::Itertools;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -24,8 +23,7 @@ pub async fn webfinger_resolve_actor<T: Clone, Kind>(
 where
     Kind: Object + Actor + Send + 'static + Object<DataType = T>,
     for<'de2> <Kind as Object>::Kind: serde::Deserialize<'de2>,
-    <Kind as Object>::Error:
-        From<crate::error::Error> + From<anyhow::Error> + From<url::ParseError> + Send + Sync,
+    <Kind as Object>::Error: From<crate::error::Error> + Send + Sync,
 {
     let (_, domain) = identifier
         .splitn(2, '@')
@@ -36,10 +34,13 @@ where
         format!("{protocol}://{domain}/.well-known/webfinger?resource=acct:{identifier}");
     debug!("Fetching webfinger url: {}", &fetch_url);
 
-    let res: Webfinger =
-        fetch_object_http_with_accept(&Url::parse(&fetch_url)?, data, "application/jrd+json")
-            .await?
-            .object;
+    let res: Webfinger = fetch_object_http_with_accept(
+        &Url::parse(&fetch_url).map_err(Error::UrlParse)?,
+        data,
+        "application/jrd+json",
+    )
+    .await?
+    .object;
 
     debug_assert_eq!(res.subject, format!("acct:{identifier}"));
     let links: Vec<Url> = res
@@ -94,14 +95,16 @@ where
 {
     // Regex to extract usernames from webfinger query. Supports different alphabets using `\p{L}`.
     // TODO: would be nice if we could implement this without regex and remove the dependency
-    let regex =
-        Regex::new(&format!(r"^acct:([\p{{L}}0-9_]+)@{}$", data.domain())).map_err(Error::other)?;
-    Ok(regex
-        .captures(query)
-        .and_then(|c| c.get(1))
-        .ok_or_else(|| Error::other(anyhow!("Webfinger regex failed to match")))?
-        .as_str()
-        .to_string())
+    let result = Regex::new(&format!(r"^acct:([\p{{L}}0-9_]+)@{}$", data.domain()))
+        .map_err(|_| Error::WebfingerRegexFailed)
+        .and_then(|regex| {
+            regex
+                .captures(query)
+                .and_then(|c| c.get(1))
+                .ok_or_else(|| Error::WebfingerRegexFailed)
+        })?;
+
+    return Ok(result.as_str().to_string());
 }
 
 /// Builds a basic webfinger response for the actor.

--- a/src/http_signatures.rs
+++ b/src/http_signatures.rs
@@ -12,7 +12,6 @@ use crate::{
     protocol::public_key::main_key_id,
     traits::{Actor, Object},
 };
-use anyhow::Context;
 use base64::{engine::general_purpose::STANDARD as Base64, Engine};
 use bytes::Bytes;
 use http::{header::HeaderName, uri::PathAndQuery, HeaderValue, Method, Uri};
@@ -83,7 +82,7 @@ pub(crate) async fn sign_request(
     activity: Bytes,
     private_key: PKey<Private>,
     http_signature_compat: bool,
-) -> Result<Request, anyhow::Error> {
+) -> Result<Request, Error> {
     static CONFIG: Lazy<Config> = Lazy::new(|| Config::new().set_expiration(EXPIRES_AFTER));
     static CONFIG_COMPAT: Lazy<Config> = Lazy::new(|| {
         Config::new()
@@ -103,14 +102,10 @@ pub(crate) async fn sign_request(
             Sha256::new(),
             activity,
             move |signing_string| {
-                let mut signer = Signer::new(MessageDigest::sha256(), &private_key)
-                    .context("instantiating signer")?;
-                signer
-                    .update(signing_string.as_bytes())
-                    .context("updating signer")?;
+                let mut signer = Signer::new(MessageDigest::sha256(), &private_key)?;
+                signer.update(signing_string.as_bytes())?;
 
-                Ok(Base64.encode(signer.sign_to_vec().context("sign to vec")?))
-                    as Result<_, anyhow::Error>
+                Ok(Base64.encode(signer.sign_to_vec()?)) as Result<_, Error>
             },
         )
         .await
@@ -152,7 +147,7 @@ pub(crate) async fn signing_actor<'a, A, H>(
 ) -> Result<A, <A as Object>::Error>
 where
     A: Object + Actor,
-    <A as Object>::Error: From<Error> + From<anyhow::Error>,
+    <A as Object>::Error: From<Error>,
     for<'de2> <A as Object>::Kind: Deserialize<'de2>,
     H: IntoIterator<Item = (&'a HeaderName, &'a HeaderValue)>,
 {
@@ -197,8 +192,8 @@ fn verify_signature_inner(
 
     let verified = CONFIG
         .begin_verify(method.as_str(), path_and_query, header_map)
-        .map_err(Error::other)?
-        .verify(|signature, signing_string| -> anyhow::Result<bool> {
+        .map_err(|val| Error::Other(val.to_string()))?
+        .verify(|signature, signing_string| -> Result<bool, Error> {
             debug!(
                 "Verifying with key {}, message {}",
                 &public_key, &signing_string
@@ -206,9 +201,13 @@ fn verify_signature_inner(
             let public_key = PKey::public_key_from_pem(public_key.as_bytes())?;
             let mut verifier = Verifier::new(MessageDigest::sha256(), &public_key)?;
             verifier.update(signing_string.as_bytes())?;
-            Ok(verifier.verify(&Base64.decode(signature)?)?)
-        })
-        .map_err(Error::other)?;
+
+            let base64_decoded = Base64
+                .decode(signature)
+                .map_err(|err| Error::Other(err.to_string()))?;
+
+            Ok(verifier.verify(&base64_decoded)?)
+        })?;
 
     if verified {
         debug!("verified signature for {}", uri);

--- a/src/protocol/verification.rs
+++ b/src/protocol/verification.rs
@@ -1,7 +1,6 @@
 //! Verify that received data is valid
 
 use crate::error::Error;
-use anyhow::anyhow;
 use url::Url;
 
 /// Check that both urls have the same domain. If not, return UrlVerificationError.
@@ -16,7 +15,7 @@ use url::Url;
 /// ```
 pub fn verify_domains_match(a: &Url, b: &Url) -> Result<(), Error> {
     if a.domain() != b.domain() {
-        return Err(Error::UrlVerificationError(anyhow!("Domains do not match")));
+        return Err(Error::UrlVerificationError("Domains do not match"));
     }
     Ok(())
 }
@@ -33,7 +32,7 @@ pub fn verify_domains_match(a: &Url, b: &Url) -> Result<(), Error> {
 /// ```
 pub fn verify_urls_match(a: &Url, b: &Url) -> Result<(), Error> {
     if a != b {
-        return Err(Error::UrlVerificationError(anyhow!("Urls do not match")));
+        return Err(Error::UrlVerificationError("Urls do not match"));
     }
     Ok(())
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -340,12 +340,12 @@ pub trait Collection: Sized {
 pub mod tests {
     use super::*;
     use crate::{
+        error::Error,
         fetch::object_id::ObjectId,
         http_signatures::{generate_actor_keypair, Keypair},
         protocol::{public_key::PublicKey, verification::verify_domains_match},
     };
     use activitystreams_kinds::{activity::FollowType, actor::PersonType};
-    use anyhow::Error;
     use once_cell::sync::Lazy;
     use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Removes `anyhow` dependency in the activitypub crate.  Resolves #80 but is a semver breaking change.

I've tested this works fine with *minor* changes to the main `lemmy` crate on this branch here: https://github.com/LemmyNet/lemmy/compare/main...cetra3:lemmy:remove_anyhow



