### PR TITLE
Webfinger: don't discard consumer errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tower = { version = "0.4.13", optional = true }
 hyper = { version = "0.14", optional = true }
 futures = "0.3.28"
 moka = { version = "0.11.3", features = ["future"] }
+unicode-properties = "0.1.0"
 
 [features]
 default = ["actix-web", "axum"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ tower = { version = "0.4.13", optional = true }
 hyper = { version = "0.14", optional = true }
 futures = "0.3.28"
 moka = { version = "0.11.3", features = ["future"] }
-unicode-properties = "0.1.0"
 
 [features]
 default = ["actix-web", "axum"]

--- a/docs/06_http_endpoints_axum.md
+++ b/docs/06_http_endpoints_axum.md
@@ -48,7 +48,7 @@ async fn http_get_user(
 ) -> impl IntoResponse {
     let accept = header_map.get("accept").map(|v| v.to_str().unwrap());
     if accept == Some(FEDERATION_CONTENT_TYPE) {
-        let db_user = data.read_local_user(name).await.unwrap();
+        let db_user = data.read_local_user(&name).await.unwrap();
         let json_user = db_user.into_json(&data).await.unwrap();
         FederationJson(WithContext::new_default(json_user)).into_response()
     }

--- a/examples/live_federation/http.rs
+++ b/examples/live_federation/http.rs
@@ -61,7 +61,7 @@ pub async fn webfinger(
     data: Data<DatabaseHandle>,
 ) -> Result<Json<Webfinger>, Error> {
     let name = extract_webfinger_name(&query.resource, &data)?;
-    let db_user = data.read_user(&name)?;
+    let db_user = data.read_user(name)?;
     Ok(Json(build_webfinger_response(
         query.resource,
         db_user.ap_id.into_inner(),

--- a/examples/local_federation/actix_web/http.rs
+++ b/examples/local_federation/actix_web/http.rs
@@ -89,7 +89,7 @@ pub async fn webfinger(
     data: Data<DatabaseHandle>,
 ) -> Result<HttpResponse, Error> {
     let name = extract_webfinger_name(&query.resource, &data)?;
-    let db_user = data.read_user(&name)?;
+    let db_user = data.read_user(name)?;
     Ok(HttpResponse::Ok().json(build_webfinger_response(
         query.resource.clone(),
         db_user.ap_id.into_inner(),

--- a/examples/local_federation/axum/http.rs
+++ b/examples/local_federation/axum/http.rs
@@ -78,7 +78,7 @@ async fn webfinger(
     data: Data<DatabaseHandle>,
 ) -> Result<Json<Webfinger>, Error> {
     let name = extract_webfinger_name(&query.resource, &data)?;
-    let db_user = data.read_user(&name)?;
+    let db_user = data.read_user(name)?;
     Ok(Json(build_webfinger_response(
         query.resource,
         db_user.ap_id.into_inner(),

--- a/src/axum/json.rs
+++ b/src/axum/json.rs
@@ -9,7 +9,7 @@
 //! # use activitypub_federation::traits::Object;
 //! # use activitypub_federation::traits::tests::{DbConnection, DbUser, Person};
 //! async fn http_get_user(Path(name): Path<String>, data: Data<DbConnection>) -> Result<FederationJson<WithContext<Person>>, Error> {
-//!     let user: DbUser = data.read_local_user(name).await?;
+//!     let user: DbUser = data.read_local_user(&name).await?;
 //!     let person = user.into_json(&data).await?;
 //!
 //!     Ok(FederationJson(WithContext::new_default(person)))

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@ use http_signature_normalization_reqwest::SignError;
 use openssl::error::ErrorStack;
 use url::Url;
 
+use crate::fetch::webfinger::WebFingerError;
+
 /// Error messages returned by this library
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -32,10 +34,7 @@ pub enum Error {
     ActivitySignatureInvalid,
     /// Failed to resolve actor via webfinger
     #[error("Failed to resolve actor via webfinger")]
-    WebfingerResolveFailed,
-    /// Failed to resolve actor via webfinger
-    #[error("Webfinger regex failed to match")]
-    WebfingerRegexFailed,
+    WebfingerResolveFailed(#[from] WebFingerError),
     /// JSON Error
     #[error(transparent)]
     Json(#[from] serde_json::Error),

--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -21,7 +21,7 @@ pub enum WebFingerError {
     #[error("The webfinger identifier doesn't match the expected instance domain name")]
     WrongDomain,
     /// The wefinger object did not contain any link to an activitypub item
-    #[error("The wefinger object did not contain any link to an activitypub item")]
+    #[error("The webfinger object did not contain any link to an activitypub item")]
     NoValidLink,
 }
 

--- a/src/fetch/webfinger.rs
+++ b/src/fetch/webfinger.rs
@@ -117,7 +117,7 @@ where
     T: Clone,
 {
     static WEBFINGER_REGEX: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^acct:([\p{L}0-9_]+)@(.*)$").unwrap());
+        Lazy::new(|| Regex::new(r"^acct:([\p{L}0-9_]+)@(.*)$").expect("compile regex"));
     // Regex to extract usernames from webfinger query. Supports different alphabets using `\p{L}`.
     // TODO: This should use a URL parser
     let captures = WEBFINGER_REGEX

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -356,7 +356,7 @@ pub mod tests {
         pub async fn read_post_from_json_id<T>(&self, _: Url) -> Result<Option<T>, Error> {
             Ok(None)
         }
-        pub async fn read_local_user(&self, _: String) -> Result<DbUser, Error> {
+        pub async fn read_local_user(&self, _: &str) -> Result<DbUser, Error> {
             todo!()
         }
         pub async fn upsert<T>(&self, _: &T) -> Result<(), Error> {


### PR DESCRIPTION
Fix #83 

Actually after looking at the code, it appears that the only time the consumer errors are actually discarded was when iterating over the links from a webfinger query. Since multiple links need to be tried there are multiple errors and it doesn't make much sense to return all of them.

Instead log the error so that it can be observed by the consumer of the library.

To resume:

This PR improves the webfinger error by:

- Making it its own enum and adding granularity
- Logging the failure when dereferencing the links from the webfinger query. This is done by adding a `Display` bound on the error type. I didn't add the full `std::error::Error` because it conflicts with some of the examples, and implementing `Error` is incompatible with `impl<T: Into<anyhow::Error>> Error for …`.
- Improving the webfinger parsing and getting rid of the regex (not fully rid of the crate since it is used in 1 more place).
The new version is equivalent to the old, tested by fuzzing.

Given that the inital issue is fixed just by adding a log line, it might make sense to drop this PR and make on that just adds the `Display` bound and the log line for simplicity.
