### PR TITLE
Upgrade axum and http

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ documentation = "https://docs.rs/activitypub_federation/"
 
 [features]
 default = ["actix-web", "axum"]
-actix-web = ["dep:actix-web"]
-axum = ["dep:axum", "dep:tower", "dep:hyper", "dep:http-body-util"]
+actix-web = ["dep:actix-web", "dep:http02"]
+axum = ["dep:axum", "dep:tower"]
 diesel = ["dep:diesel"]
 
 [lints.rust]
@@ -37,18 +37,18 @@ serde = { version = "1.0.204", features = ["derive"] }
 async-trait = "0.1.81"
 url = { version = "2.5.2", features = ["serde"] }
 serde_json = { version = "1.0.120", features = ["preserve_order"] }
-reqwest = { version = "0.11.27", default-features = false, features = [
+reqwest = { version = "0.12.5", default-features = false, features = [
   "json",
   "stream",
   "rustls-tls",
 ] }
-reqwest-middleware = "0.2.5"
+reqwest-middleware = "0.3.2"
 tracing = "0.1.40"
 base64 = "0.22.1"
 rand = "0.8.5"
 rsa = "0.9.6"
 once_cell = "1.19.0"
-http = "0.2.12"
+http = "1.1.0"
 sha2 = { version = "0.10.8", features = ["oid"] }
 thiserror = "1.0.62"
 derive_builder = "0.20.0"
@@ -56,7 +56,7 @@ itertools = "0.13.0"
 dyn-clone = "1.0.17"
 enum_delegate = "0.2.0"
 httpdate = "1.0.3"
-http-signature-normalization-reqwest = { version = "0.10.0", default-features = false, features = [
+http-signature-normalization-reqwest = { version = "0.12.0", default-features = false, features = [
   "sha-2",
   "middleware",
   "default-spawner",
@@ -84,26 +84,17 @@ moka = { version = "0.12.8", features = ["future"] }
 
 # Actix-web
 actix-web = { version = "4.8.0", default-features = false, optional = true }
+http02 = { package = "http", version = "0.2.12", optional = true }
 
 # Axum
-axum = { version = "0.6.20", features = [
-  "json",
-  "headers",
-], default-features = false, optional = true }
+axum = { version = "0.7.5", features = ["json"], default-features = false, optional = true }
 tower = { version = "0.4.13", optional = true }
-hyper = { version = "0.14", optional = true }
-http-body-util = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.86"
+axum = { version = "0.7.5", features = ["macros"] }
+axum-extra = { version = "0.9.3", features = ["typed-header"] }
 env_logger = "0.11.3"
-tower-http = { version = "0.5.2", features = ["map-request-body", "util"] }
-axum = { version = "0.6.20", features = [
-  "http1",
-  "tokio",
-  "query",
-], default-features = false }
-axum-macros = "0.3.8"
 tokio = { version = "1.38.0", features = ["full"] }
 
 [profile.dev]

--- a/docs/06_http_endpoints_axum.md
+++ b/docs/06_http_endpoints_axum.md
@@ -15,9 +15,9 @@ The next step is to allow other servers to fetch our actors and objects. For thi
 # use activitypub_federation::config::FederationMiddleware;
 # use axum::routing::get;
 # use crate::activitypub_federation::traits::Object;
-# use axum::headers::ContentType;
+# use axum_extra::headers::ContentType;
 # use activitypub_federation::FEDERATION_CONTENT_TYPE;
-# use axum::TypedHeader;
+# use axum_extra::TypedHeader;
 # use axum::response::IntoResponse;
 # use http::HeaderMap;
 # async fn generate_user_html(_: String, _: Data<DbConnection>) -> axum::response::Response { todo!() }
@@ -34,10 +34,9 @@ async fn main() -> Result<(), Error> {
         .layer(FederationMiddleware::new(data));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::debug!("listening on {}", addr);
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
+    axum::serve(listener, app.into_make_service()).await?;
     Ok(())
 }
 

--- a/examples/live_federation/http.rs
+++ b/examples/live_federation/http.rs
@@ -14,11 +14,11 @@ use activitypub_federation::{
     traits::Object,
 };
 use axum::{
+    debug_handler,
     extract::{Path, Query},
     response::{IntoResponse, Response},
     Json,
 };
-use axum_macros::debug_handler;
 use http::StatusCode;
 use serde::Deserialize;
 

--- a/examples/live_federation/main.rs
+++ b/examples/live_federation/main.rs
@@ -64,9 +64,8 @@ async fn main() -> Result<(), Error> {
         .to_socket_addrs()?
         .next()
         .expect("Failed to lookup domain name");
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
 
     Ok(())
 }

--- a/examples/local_federation/axum/http.rs
+++ b/examples/local_federation/axum/http.rs
@@ -18,7 +18,8 @@ use axum::{
     extract::{Path, Query},
     response::IntoResponse,
     routing::{get, post},
-    Json, Router,
+    Json,
+    Router,
 };
 use serde::Deserialize;
 use std::net::ToSocketAddrs;

--- a/examples/local_federation/axum/http.rs
+++ b/examples/local_federation/axum/http.rs
@@ -14,13 +14,12 @@ use activitypub_federation::{
     traits::Object,
 };
 use axum::{
+    debug_handler,
     extract::{Path, Query},
     response::IntoResponse,
     routing::{get, post},
-    Json,
-    Router,
+    Json, Router,
 };
-use axum_macros::debug_handler;
 use serde::Deserialize;
 use std::net::ToSocketAddrs;
 use tracing::info;
@@ -39,9 +38,14 @@ pub fn listen(config: &FederationConfig<DatabaseHandle>) -> Result<(), Error> {
         .to_socket_addrs()?
         .next()
         .expect("Failed to lookup domain name");
-    let server = axum::Server::bind(&addr).serve(app.into_make_service());
+    let fut = async move {
+        let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    };
 
-    tokio::spawn(server);
+    tokio::spawn(fut);
     Ok(())
 }
 

--- a/src/activity_queue.rs
+++ b/src/activity_queue.rs
@@ -451,8 +451,8 @@ mod tests {
             .route("/", post(dodgy_handler))
             .with_state(state);
 
-        axum::Server::bind(&"0.0.0.0:8002".parse().unwrap())
-            .serve(app.into_make_service())
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:8002").await.unwrap();
+        axum::serve(listener, app.into_make_service())
             .await
             .unwrap();
     }

--- a/src/activity_sending.rs
+++ b/src/activity_sending.rs
@@ -251,8 +251,8 @@ mod tests {
             .route("/", post(dodgy_handler))
             .with_state(state);
 
-        axum::Server::bind(&"0.0.0.0:8001".parse().unwrap())
-            .serve(app.into_make_service())
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:8001").await.unwrap();
+        axum::serve(listener, app.into_make_service())
             .await
             .unwrap();
     }

--- a/src/actix_web/http_compat.rs
+++ b/src/actix_web/http_compat.rs
@@ -1,0 +1,29 @@
+#![allow(clippy::unwrap_used)]
+
+use std::str::FromStr;
+
+pub fn header_value(v: &http02::HeaderValue) -> http::HeaderValue {
+    http::HeaderValue::from_bytes(v.as_bytes()).unwrap()
+}
+
+pub fn header_map<'a, H>(m: H) -> http::HeaderMap
+where
+    H: IntoIterator<Item = (&'a http02::HeaderName, &'a http02::HeaderValue)>,
+{
+    let mut new_map = http::HeaderMap::new();
+    for (n, v) in m {
+        new_map.insert(
+            http::HeaderName::from_lowercase(n.as_str().as_bytes()).unwrap(),
+            header_value(v),
+        );
+    }
+    new_map
+}
+
+pub fn method(m: &http02::Method) -> http::Method {
+    http::Method::from_bytes(m.as_str().as_bytes()).unwrap()
+}
+
+pub fn uri(m: &http02::Uri) -> http::Uri {
+    http::Uri::from_str(&m.to_string()).unwrap()
+}

--- a/src/actix_web/http_compat.rs
+++ b/src/actix_web/http_compat.rs
@@ -1,9 +1,9 @@
-#![allow(clippy::unwrap_used)]
+//! Remove these conversion helpers after actix-web upgrades to http 1.0
 
 use std::str::FromStr;
 
 pub fn header_value(v: &http02::HeaderValue) -> http::HeaderValue {
-    http::HeaderValue::from_bytes(v.as_bytes()).unwrap()
+    http::HeaderValue::from_bytes(v.as_bytes()).expect("can convert http types")
 }
 
 pub fn header_map<'a, H>(m: H) -> http::HeaderMap
@@ -13,7 +13,8 @@ where
     let mut new_map = http::HeaderMap::new();
     for (n, v) in m {
         new_map.insert(
-            http::HeaderName::from_lowercase(n.as_str().as_bytes()).unwrap(),
+            http::HeaderName::from_lowercase(n.as_str().as_bytes())
+                .expect("can convert http types"),
             header_value(v),
         );
     }
@@ -21,9 +22,9 @@ where
 }
 
 pub fn method(m: &http02::Method) -> http::Method {
-    http::Method::from_bytes(m.as_str().as_bytes()).unwrap()
+    http::Method::from_bytes(m.as_str().as_bytes()).expect("can convert http types")
 }
 
 pub fn uri(m: &http02::Uri) -> http::Uri {
-    http::Uri::from_str(&m.to_string()).unwrap()
+    http::Uri::from_str(&m.to_string()).expect("can convert http types")
 }

--- a/src/actix_web/inbox.rs
+++ b/src/actix_web/inbox.rs
@@ -64,6 +64,7 @@ mod test {
     use serde_json::json;
     use url::Url;
 
+    /// Remove this conversion helper after actix-web upgrades to http 1.0
     fn header_pair(
         p: (&http::HeaderName, &http::HeaderValue),
     ) -> (http02::HeaderName, http02::HeaderValue) {

--- a/src/axum/inbox.rs
+++ b/src/axum/inbox.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use axum::{
     async_trait,
-    body::{Bytes, HttpBody},
+    body::Body,
     extract::FromRequest,
     http::{Request, StatusCode},
     response::{IntoResponse, Response},
@@ -59,21 +59,17 @@ pub struct ActivityData {
 }
 
 #[async_trait]
-impl<S, B> FromRequest<S, B> for ActivityData
+impl<S> FromRequest<S> for ActivityData
 where
-    Bytes: FromRequest<S, B>,
-    B: HttpBody + Send + 'static,
     S: Send + Sync,
-    <B as HttpBody>::Error: std::fmt::Display,
-    <B as HttpBody>::Data: Send,
 {
     type Rejection = Response;
 
-    async fn from_request(req: Request<B>, _state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(req: Request<Body>, _state: &S) -> Result<Self, Self::Rejection> {
         let (parts, body) = req.into_parts();
 
         // this wont work if the body is an long running stream
-        let bytes = hyper::body::to_bytes(body)
+        let bytes = axum::body::to_bytes(body, usize::MAX)
             .await
             .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response())?;
 


### PR DESCRIPTION
This PR upgrades http to 1.x, and upgrades corresponding crates (axum, reqwest, ...).

Resolves #87

For actix-web support, this PR converts http 1.x types to http 0.2 with naive `unwrap`ing.