### PR TITLE
Avoid stack overflow when fetching deeply nested comments

### DIFF
--- a/src/fetch/object_id.rs
+++ b/src/fetch/object_id.rs
@@ -147,7 +147,7 @@ where
     }
 
     /// Fetch object from origin instance over HTTP, then verify and parse it.
-    /// 
+    ///
     /// Uses Box::pin to wrap futures to reduce stack size and avoid stack overflow when
     /// when fetching objects recursively.
     async fn dereference_from_http(

--- a/src/fetch/object_id.rs
+++ b/src/fetch/object_id.rs
@@ -154,7 +154,7 @@ where
     where
         <Kind as Object>::Error: From<Error>,
     {
-        let res = fetch_object_http(&self.0, data).await;
+        let res = Box::pin(fetch_object_http(&self.0, data)).await;
 
         if let Err(Error::ObjectDeleted(url)) = res {
             if let Some(db_object) = db_object {
@@ -166,8 +166,8 @@ where
         let res = res?;
         let redirect_url = &res.url;
 
-        Kind::verify(&res.object, redirect_url, data).await?;
-        Kind::from_json(res.object, data).await
+        Box::pin(Kind::verify(&res.object, redirect_url, data)).await?;
+        Box::pin(Kind::from_json(res.object, data)).await
     }
 
     /// Returns true if the object's domain matches the one defined in [[FederationConfig.domain]].

--- a/src/fetch/object_id.rs
+++ b/src/fetch/object_id.rs
@@ -146,6 +146,10 @@ where
         Object::read_from_id(*id, data).await
     }
 
+    /// Fetch object from origin instance over HTTP, then verify and parse it.
+    /// 
+    /// Uses Box::pin to wrap futures to reduce stack size and avoid stack overflow when
+    /// when fetching objects recursively.
     async fn dereference_from_http(
         &self,
         data: &Data<<Kind as Object>::DataType>,


### PR DESCRIPTION
Use Box::pin to reduce stack size and allow deeper recursion. See https://github.com/LemmyNet/lemmy/pull/5009