### PR TITLE
Update reqwest dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,12 @@ serde = { version = "1.0.204", features = ["derive"] }
 async-trait = "0.1.81"
 url = { version = "2.5.2", features = ["serde"] }
 serde_json = { version = "1.0.120", features = ["preserve_order"] }
-reqwest = { version = "0.12.5", default-features = false, features = [
+reqwest = { version = "0.12.18", default-features = false, features = [
   "json",
   "stream",
   "rustls-tls",
 ] }
-reqwest-middleware = "0.3.2"
+reqwest-middleware = "0.4.2"
 tracing = "0.1.40"
 base64 = "0.22.1"
 rand = "0.8.5"
@@ -56,7 +56,7 @@ itertools = "0.13.0"
 dyn-clone = "1.0.17"
 enum_delegate = "0.2.0"
 httpdate = "1.0.3"
-http-signature-normalization-reqwest = { version = "0.12.0", default-features = false, features = [
+http-signature-normalization-reqwest = { version = "0.13.0", default-features = false, features = [
   "sha-2",
   "middleware",
   "default-spawner",


### PR DESCRIPTION
I was merging the Lemmy backend's main branch into the feature branch I made for the [lemmy_api_common issue](https://github.com/LemmyNet/lemmy/issues/5642) when I encountered this build error:

```
error[E0308]: mismatched types
   --> crates/apub/src/http/mod.rs:158:40
    |
158 |         let req = context.sign_request(req, Bytes::new()).await?;
    |                           ------------ ^^^ expected `RequestBuilder`, found a different `RequestBuilder`
    |                           |
    |                           arguments to this method are incorrect
    |
note: two different versions of crate `reqwest_middleware` are being used; two types coming from two different versions of the same crate are different types even if they look the same
   --> /home/insomnia/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-middleware-0.3.3/src/client.rs:325:1
    |
325 | pub struct RequestBuilder {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ this is the expected type `reqwest_middleware::client::RequestBuilder`
    |
   ::: /home/insomnia/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-middleware-0.4.2/src/client.rs:326:1
    |
326 | pub struct RequestBuilder {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ this is the found type `reqwest_middleware::client::RequestBuilder`
    |
   ::: crates/apub/src/lib.rs:1:5
    |
1   | use activitypub_federation::{
    |     ---------------------- one version of crate `reqwest_middleware` used here, as a dependency of crate `activitypub_federation`
...
6   | use lemmy_api_utils::context::LemmyContext;
    |     --------------- one version of crate `reqwest_middleware` used here, as a dependency of crate `lemmy_utils`
    = help: you can use `cargo tree` to explore your dependency tree
note: method defined here
   --> /home/insomnia/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/activitypub_federation-0.6.5/src/config.rs:386:18
    |
386 |     pub async fn sign_request(&self, req: RequestBuilder, body: Bytes) -> Result<Request, Erro...
    |                  ^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `lemmy_apub` (lib) due to 1 previous error

```

This likely occurred due to me deleting the project's `Cargo.lock` file and trying to regenerate it to resolve the merge conflict. Looking at the newly generated `Cargo.lock`, I noticed that the dependencies using `reqwest-middleware` 0.3.x came from this dependency.

This fix bumps up the relevant dependency versions, and the update compiled without issue. Once this PR gets merged, I should easily be able to resolve the merge conflict for the `lemmy_api_common` branch and will open a draft PR with those changes.

**Note**: Once this is merged, a new version should be published. Should probably go with 0.7.0 instead of 0.6.6 since a project depending on the current version will possibly have a similar breaking transient dependency conflict like the Lemmy backend project currently does.