### PR TITLE
Implement Clone for Data struct

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -414,11 +414,17 @@ impl<T: Clone> Deref for Data<T> {
 
 impl<T: Clone> Clone for Data<T> {
     fn clone(&self) -> Self {
-        Data { config: self.config.clone(), request_counter: self.request_counter.load(Ordering::Relaxed).into() }
+        Data {
+            config: self.config.clone(),
+            request_counter: self.request_counter.load(Ordering::Relaxed).into(),
+        }
     }
 
     fn clone_from(&mut self, source: &Self) {
-        let Data { config, request_counter } = self;
+        let Data {
+            config,
+            request_counter,
+        } = self;
         config.clone_from(&source.config);
         *request_counter.get_mut() = source.request_counter.load(Ordering::Relaxed);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -412,6 +412,18 @@ impl<T: Clone> Deref for Data<T> {
     }
 }
 
+impl<T: Clone> Clone for Data<T> {
+    fn clone(&self) -> Self {
+        Data { config: self.config.clone(), request_counter: self.request_counter.load(Ordering::Relaxed).into() }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        let Data { config, request_counter } = self;
+        config.clone_from(&source.config);
+        *request_counter.get_mut() = source.request_counter.load(Ordering::Relaxed);
+    }
+}
+
 /// Middleware for HTTP handlers which provides access to [Data]
 #[derive(Clone)]
 pub struct FederationMiddleware<T: Clone>(pub(crate) FederationConfig<T>);

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -106,7 +106,7 @@ async fn fetch_object_http_with_accept<T: Clone, Kind: DeserializeOwned>(
     config.verify_url_valid(url).await?;
     info!("Fetching remote object {}", url.to_string());
 
-    let mut counter = data.request_counter.fetch_add(1, Ordering::SeqCst);
+    let mut counter = data.request_counter.0.fetch_add(1, Ordering::SeqCst);
     // fetch_add returns old value so we need to increment manually here
     counter += 1;
     if counter > config.http_fetch_limit {


### PR DESCRIPTION
I'm about to make a Lemmy PR that needs this because it uses `tokio::spawn` to prevent stack overflow and the spawned task needs a clone of `Data`.